### PR TITLE
fix joystream channel id type from string to number

### DIFF
--- a/packages/api/api-spec.json
+++ b/packages/api/api-spec.json
@@ -212,26 +212,18 @@
         ]
       }
     },
-    "/channels/{id}/videos": {
+    "/channels/{joystreamChannelId}/videos": {
       "get": {
         "operationId": "ChannelsController_getVideos",
         "summary": "",
-        "description": "Retrieves already ingested(spotted on youtube and saved to the database) videos for a given channel.",
+        "description": "Retrieves all videos (in the backend system) for a given youtube channel by its corresponding joystream channel Id.",
         "parameters": [
           {
-            "name": "userId",
+            "name": "joystreamChannelId",
             "required": true,
             "in": "path",
             "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "id",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
+              "type": "number"
             }
           }
         ],

--- a/packages/api/src/channels/channels.controller.ts
+++ b/packages/api/src/channels/channels.controller.ts
@@ -157,9 +157,14 @@ export class ChannelsController {
     description: `Retrieves all videos (in the backend system) for a given youtube channel by its corresponding joystream channel Id.`,
   })
   async getVideos(@Param('joystreamChannelId', ParseIntPipe) id: number): Promise<Video[]> {
-    const channelId = (await this.channelsService.get(id)).id
-    const result = await this.videosRepository.query({ channelId }, (q) => q.sort('descending'))
-    return result
+    try {
+      const channelId = (await this.channelsService.get(id)).id
+      const result = await this.videosRepository.query({ channelId }, (q) => q.sort('descending'))
+      return result
+    } catch (error) {
+      const message = error instanceof Error ? error.message : error
+      throw new NotFoundException(message)
+    }
   }
 
   @Get(':id/videos/:videoId')

--- a/packages/api/src/channels/channels.controller.ts
+++ b/packages/api/src/channels/channels.controller.ts
@@ -9,13 +9,14 @@ import {
   NotFoundException,
   Param,
   ParseArrayPipe,
+  ParseIntPipe,
   Post,
   Put,
   UnauthorizedException,
   UseGuards,
 } from '@nestjs/common'
 import { ApiBody, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger'
-import { Channel, User } from '@youtube-sync/domain'
+import { Channel, User, Video } from '@youtube-sync/domain'
 import {
   ChannelDto,
   SaveChannelRequest,
@@ -77,7 +78,7 @@ export class ChannelsController {
   @Get(':joystreamChannelId')
   @ApiOperation({ description: 'Retrieves channel by joystreamChannelId' })
   @ApiResponse({ type: ChannelDto })
-  async get(@Param('joystreamChannelId') id: number) {
+  async get(@Param('joystreamChannelId', ParseIntPipe) id: number) {
     try {
       const channel = await this.channelsService.get(id)
       return new ChannelDto(channel)
@@ -150,13 +151,14 @@ export class ChannelsController {
     }
   }
 
-  @Get(':id/videos')
+  @Get(':joystreamChannelId/videos')
   @ApiResponse({ type: VideoDto, isArray: true })
   @ApiOperation({
-    description: `Retrieves already ingested(spotted on youtube and saved to the database) videos for a given channel.`,
+    description: `Retrieves all videos (in the backend system) for a given youtube channel by its corresponding joystream channel Id.`,
   })
-  async getVideos(@Param('userId') userId: string, @Param('id') id: string) {
-    const result = await this.videosRepository.query({ channelId: id }, (q) => q.sort('descending'))
+  async getVideos(@Param('joystreamChannelId', ParseIntPipe) id: number): Promise<Video[]> {
+    const channelId = (await this.channelsService.get(id)).id
+    const result = await this.videosRepository.query({ channelId }, (q) => q.sort('descending'))
     return result
   }
 

--- a/packages/api/src/channels/channels.service.ts
+++ b/packages/api/src/channels/channels.service.ts
@@ -1,8 +1,6 @@
 import { ChannelsRepository } from '@joystream/ytube'
 import { Injectable } from '@nestjs/common'
 import { Channel } from '@youtube-sync/domain'
-import { AnyDocument } from 'dynamoose/dist/Document'
-import { Query } from 'dynamoose/dist/DocumentRetriever'
 
 @Injectable()
 export class ChannelsService {


### PR DESCRIPTION
This PR

- supersedes #71 
- Changes endpoint `/channels/{id}/videos` -> `/channels/{joystreamChannelId}/videos`, i.e. Returns all videos of a YouTube channel by its corresponding joystreamChannelId 