### PR TITLE
accept video category info from creator for synced videos

### DIFF
--- a/packages/api/api-spec.json
+++ b/packages/api/api-spec.json
@@ -438,6 +438,9 @@
           "joystreamChannelId": {
             "type": "number"
           },
+          "videoCategoryId": {
+            "type": "string"
+          },
           "referrerChannelId": {
             "type": "number"
           }
@@ -446,7 +449,8 @@
           "authorizationCode",
           "userId",
           "email",
-          "joystreamChannelId"
+          "joystreamChannelId",
+          "videoCategoryId"
         ]
       },
       "UserDto": {
@@ -508,6 +512,9 @@
           "joystreamChannelId": {
             "type": "number"
           },
+          "videoCategoryId": {
+            "type": "string"
+          },
           "thumbnails": {
             "$ref": "#/components/schemas/ThumbnailsDto"
           },
@@ -526,6 +533,7 @@
           "shouldBeIngested",
           "isSuspended",
           "joystreamChannelId",
+          "videoCategoryId",
           "thumbnails",
           "subscribersCount",
           "createdAt"
@@ -584,6 +592,9 @@
           "description": {
             "type": "string"
           },
+          "category": {
+            "type": "string"
+          },
           "id": {
             "type": "string"
           },
@@ -610,6 +621,7 @@
           "url",
           "title",
           "description",
+          "category",
           "id",
           "playlistId",
           "resourceId",

--- a/packages/api/src/channels/channels.controller.ts
+++ b/packages/api/src/channels/channels.controller.ts
@@ -48,7 +48,8 @@ export class ChannelsController {
   @ApiResponse({ type: SaveChannelResponse })
   @Post()
   async addVerifiedChannel(
-    @Body() { authorizationCode, userId, joystreamChannelId, referrerChannelId, email }: SaveChannelRequest
+    @Body()
+    { authorizationCode, userId, joystreamChannelId, referrerChannelId, email, videoCategoryId }: SaveChannelRequest
   ): Promise<SaveChannelResponse> {
     try {
       // get user from userId
@@ -63,7 +64,7 @@ export class ChannelsController {
       const [channel] = await this.youtube.getChannels(user)
 
       const updatedUser: User = { ...user, email }
-      const updatedChannel: Channel = { ...channel, joystreamChannelId, referrerChannelId, email }
+      const updatedChannel: Channel = { ...channel, joystreamChannelId, referrerChannelId, email, videoCategoryId }
 
       // save user and channel
       await this.saveUserAndChannel(updatedUser, updatedChannel)

--- a/packages/api/src/dtos.ts
+++ b/packages/api/src/dtos.ts
@@ -39,6 +39,7 @@ export class ChannelDto {
   @ApiProperty() shouldBeIngested: boolean
   @ApiProperty() isSuspended: boolean
   @ApiProperty() joystreamChannelId: number
+  @ApiProperty() videoCategoryId: string
   @ApiProperty() thumbnails: ThumbnailsDto
   @ApiProperty() subscribersCount: number
   @ApiProperty() createdAt: Date
@@ -48,6 +49,7 @@ export class ChannelDto {
     this.description = channel.description
     this.subscribersCount = channel.statistics.subscriberCount
     this.joystreamChannelId = channel.joystreamChannelId
+    this.videoCategoryId = channel.videoCategoryId
     this.shouldBeIngested = channel.shouldBeIngested
     this.isSuspended = channel.isSuspended
     this.aggregatedStats = channel.aggregatedStats
@@ -97,6 +99,9 @@ export class SaveChannelRequest {
   // Joystream Channel ID of the user verifying his Youtube Channel for YPP
   @IsNotEmpty() @ApiProperty({ required: true }) joystreamChannelId: number
 
+  // video category ID to be added to all synced videos
+  @IsNotEmpty() @ApiProperty({ required: true }) videoCategoryId: string
+
   // referrer Channel ID
   @ApiProperty({ required: false }) referrerChannelId: number
 }
@@ -116,6 +121,7 @@ export class VideoDto extends Video {
   @ApiProperty() url: string
   @ApiProperty() title: string
   @ApiProperty() description: string
+  @ApiProperty() category: string
   @ApiProperty() id: string
   @ApiProperty() playlistId: string
   @ApiProperty() resourceId: string

--- a/packages/domain/src/domain.ts
+++ b/packages/domain/src/domain.ts
@@ -1,5 +1,3 @@
-import { MemberId } from '@joystream/types/primitives'
-
 export class Channel {
   // Channel ID
   id: string
@@ -12,6 +10,9 @@ export class Channel {
 
   // ID of the corresponding Joystream Channel
   joystreamChannelId: number
+
+  // video category ID to be added to all synced videos
+  videoCategoryId: string
 
   // Referrer Joystream Channel ID
   referrerChannelId: number
@@ -210,6 +211,9 @@ export class Video {
 
   // youtube video license
   license: string
+
+  // Joystream video category to be assigned to synced videos
+  category: string
 }
 
 export class Stats {

--- a/packages/joy-api/src/client.ts
+++ b/packages/joy-api/src/client.ts
@@ -87,6 +87,7 @@ async function parseVideoInputs(video: Video): Promise<[VideoInputMetadata, Vide
 }
 
 async function getThumbnailAsset(thumbnails: Thumbnails) {
+  // * We are using `medium` thumbnail because it has correct aspect ratio for Atlas (16/9)
   const response = await axios.get<Readable>(thumbnails.medium, { responseType: 'stream' })
   return response.data
 }

--- a/packages/ytube/src/lib/database.ts
+++ b/packages/ytube/src/lib/database.ts
@@ -32,6 +32,9 @@ export function createChannelModel(): ModelType<AnyDocument> {
       // ID of the corresponding Joystream Channel
       joystreamChannelId: Number,
 
+      // video category ID to be added to all synced videos
+      videoCategoryId: String,
+
       // Referrer's Joystream Channel ID
       referrerChannelId: Number,
 
@@ -189,6 +192,7 @@ export function videoRepository() {
       playlistId: String,
 
       resourceId: String,
+
       thumbnails: {
         type: Object,
         schema: {
@@ -205,6 +209,9 @@ export function videoRepository() {
         type: String,
         enum: videoStates,
       },
+
+      // Joystream video category to be assigned to synced videos
+      category: String,
     },
     {
       saveUnknown: true,

--- a/packages/ytube/src/lib/youtubeClient.ts
+++ b/packages/ytube/src/lib/youtubeClient.ts
@@ -169,7 +169,7 @@ class YoutubeClient implements IYoutubeClient {
         maxResults: 50,
       })
       continuation = nextPage.data.nextPageToken ?? ''
-      const page = this.mapVideos(nextPage.data.items ?? [])
+      const page = this.mapVideos(nextPage.data.items ?? [], channel)
       videos = [...videos, ...page]
     } while (continuation && videos.length < max)
     return videos
@@ -209,7 +209,7 @@ class YoutubeClient implements IYoutubeClient {
     )
   }
 
-  private mapVideos(videos: Schema$PlaylistItem[]) {
+  private mapVideos(videos: Schema$PlaylistItem[], channel: Channel) {
     return videos.map(
       (video) =>
         <Video>{
@@ -227,6 +227,7 @@ class YoutubeClient implements IYoutubeClient {
           resourceId: video.snippet?.resourceId?.videoId,
           publishedAt: video.contentDetails.videoPublishedAt,
           createdAt: Date.now(),
+          category: channel.videoCategoryId,
           state: 'New',
         }
     )


### PR DESCRIPTION
This PR addresses:

- #77 
- change YT video thumbnail to be used for synced videos from `default` to `medium` due to inconsistent aspect ratio issue.