### PR TITLE
fix: YPP onboarding videos requirements check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,17 @@
+# Use the specified image as base
 FROM node:14
 
 # Set the working directory to /youtube-synch
 WORKDIR /youtube-synch
 
-# Copy the contents of the current directory to /youtube-synch
-COPY . /youtube-synch
+# Copy the package.json and yarn.lock (or package-lock.json for npm) files
+COPY package.json yarn.lock ./
 
 # Install dependencies
 RUN yarn install
+
+# Copy the rest of your application
+COPY . .
 
 # Build the project
 RUN yarn build

--- a/config.yml
+++ b/config.yml
@@ -12,7 +12,7 @@ logs:
   console:
     level: verbose
   # elastic:
-  #   level: info
+  #   level: http
   #   endpoint: http://localhost:9200
   #   auth:
   #     username: elastic-username

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,8 @@ services:
       context: .
       dockerfile: Dockerfile
     volumes:
-      - logs:/logs
-      - data:/data
+      - ./local/logs:/youtube-synch/local/logs
+      - ./local/data:/youtube-synch/local/data
       # mount the AWS credentials file to docker container home directory
       - ~/.aws/:/root/.aws:ro
     env_file:

--- a/src/repository/video.ts
+++ b/src/repository/video.ts
@@ -233,16 +233,6 @@ export class VideosService {
     return await this.videosRepository.save({ ...video, state })
   }
 
-  async getCountByChannel(channelId: string) {
-    const videosCountByChannel = (await (await this.videosRepository.getModel())
-      .query('channelId')
-      .eq(channelId)
-      .count()
-      .exec()) as unknown as { count: string }
-
-    return parseInt(videosCountByChannel.count)
-  }
-
   async getVideosInState(state: VideoState): Promise<YtVideo[]> {
     return this.videosRepository.query({ state }, (q) => q.sort('ascending').using('state-publishedAt-index'))
   }

--- a/src/services/query-node/generated/queries.ts
+++ b/src/services/query-node/generated/queries.ts
@@ -48,8 +48,8 @@ export type VideoFieldsFragment = {
   id: string
   ytVideoId?: Types.Maybe<string>
   entryApp?: Types.Maybe<{ id: string; name: string }>
-  media?: Types.Maybe<{ isAccepted: boolean }>
-  thumbnailPhoto?: Types.Maybe<{ isAccepted: boolean }>
+  media?: Types.Maybe<{ id: string; isAccepted: boolean }>
+  thumbnailPhoto?: Types.Maybe<{ id: string; isAccepted: boolean }>
 }
 
 export type GetVideoByYtResourceIdAndEntryAppNameQueryVariables = Types.Exact<{
@@ -216,9 +216,11 @@ export const VideoFields = gql`
       name
     }
     media {
+      id
       isAccepted
     }
     thumbnailPhoto {
+      id
       isAccepted
     }
   }

--- a/src/services/query-node/queries/content.graphql
+++ b/src/services/query-node/queries/content.graphql
@@ -29,9 +29,11 @@ fragment VideoFields on Video {
     name
   }
   media {
+    id
     isAccepted
   }
   thumbnailPhoto {
+    id
     isAccepted
   }
 }

--- a/src/services/runtime/client.ts
+++ b/src/services/runtime/client.ts
@@ -74,7 +74,7 @@ export class JoystreamClient {
     }
 
     if (blockNumber.gtn(qnState.lastCompleteBlock)) {
-      this.logger.warn(
+      this.logger.debug(
         `Query Node has not processed block ${blockNumber.toString()} yet. Last processed block: ${
           qnState.lastCompleteBlock
         }`

--- a/src/services/syncProcessing/YoutubePollingService.ts
+++ b/src/services/syncProcessing/YoutubePollingService.ts
@@ -168,9 +168,9 @@ export class YoutubePollingService {
     return updatedChannels.filter((ch) => ch.shouldBeIngested)
   }
 
-  private async performVideosIngestion(channel: YtChannel, top = 1000) {
+  private async performVideosIngestion(channel: YtChannel) {
     // get all sync-able videos of the channel
-    const allVideos = await this.youtubeApi.getAllVideos(channel, top)
+    const allVideos = await this.youtubeApi.getAllVideos(channel)
 
     // get all unsynced videos
     const unsyncedVideos = await this.getUnsyncedVideos(channel, allVideos)

--- a/src/services/youtube/api.ts
+++ b/src/services/youtube/api.ts
@@ -150,9 +150,7 @@ class YoutubeClient implements IYoutubeApi {
     videoCreationTimeCutoff.setHours(videoCreationTimeCutoff.getHours() - minimumVideoAgeHours)
 
     // filter all videos that are older than MINIMUM_VIDEO_AGE_HOURS
-    const videos = (await this.getVideos(channel, minimumVideoCount)).filter(
-      (v) => new Date(v.publishedAt) < videoCreationTimeCutoff
-    )
+    const videos = (await this.getAllVideos(channel)).filter((v) => new Date(v.publishedAt) < videoCreationTimeCutoff)
     if (videos.length < minimumVideoCount) {
       errors.push(
         new YoutubeApiError(

--- a/src/services/youtube/api.ts
+++ b/src/services/youtube/api.ts
@@ -20,7 +20,7 @@ export interface IYoutubeApi {
   getChannel(user: Pick<YtUser, 'id' | 'accessToken' | 'refreshToken'>): Promise<YtChannel>
   verifyChannel(channel: YtChannel): Promise<YtChannel>
   getVideos(channel: YtChannel, top: number): Promise<YtVideo[]>
-  getAllVideos(channel: YtChannel, max: number): Promise<YtVideo[]>
+  getAllVideos(channel: YtChannel): Promise<YtVideo[]>
   downloadVideo(videoUrl: string, outPath: string): ReturnType<typeof ytdl>
   getCreatorOnboardingRequirements(): ReadonlyConfig['creatorOnboardingRequirements']
 }
@@ -197,10 +197,10 @@ class YoutubeClient implements IYoutubeApi {
     }
   }
 
-  async getAllVideos(channel: YtChannel, max = 500) {
+  async getAllVideos(channel: YtChannel) {
     const yt = this.getYoutube(channel.userAccessToken, channel.userRefreshToken)
     try {
-      return this.iterateVideos(yt, channel, max)
+      return this.iterateVideos(yt, channel)
     } catch (error) {
       throw new Error(`Failed to fetch videos for channel ${channel.title}. Error: ${error}`)
     }
@@ -217,9 +217,9 @@ class YoutubeClient implements IYoutubeApi {
     return response
   }
 
-  private async iterateVideos(youtube: youtube_v3.Youtube, channel: YtChannel, max: number) {
+  private async iterateVideos(youtube: youtube_v3.Youtube, channel: YtChannel, limit?: number) {
     let videos: YtVideo[] = []
-    let continuation: string | undefined
+    let nextPageToken: string | undefined
 
     do {
       const nextPage = await youtube.playlistItems
@@ -227,7 +227,7 @@ class YoutubeClient implements IYoutubeApi {
           part: ['contentDetails', 'snippet', 'id', 'status'],
           playlistId: channel.uploadsPlaylistId,
           maxResults: 50,
-          pageToken: continuation,
+          pageToken: nextPageToken,
         })
         .catch((err) => {
           if (err instanceof FetchError && err.code === 'ENOTFOUND') {
@@ -235,13 +235,16 @@ class YoutubeClient implements IYoutubeApi {
           }
           throw err
         })
-      continuation = nextPage.data.nextPageToken ?? ''
+      nextPageToken = nextPage.data.nextPageToken ?? ''
 
-      const videosDetails = nextPage.data.items?.length
+      // Filter `public` videos as only those would be synced
+      const videosPage = nextPage.data.items?.filter((v) => v.status?.privacyStatus === 'public') ?? []
+
+      const videosDetailsPage = videosPage.length
         ? (
             await youtube.videos
               .list({
-                id: nextPage.data.items?.map((v) => v.snippet?.resourceId?.videoId ?? ``),
+                id: videosPage?.map((v) => v.snippet?.resourceId?.videoId ?? ``),
                 part: ['contentDetails', 'fileDetails', 'snippet', 'id', 'status', 'statistics'],
               })
               .catch((err) => {
@@ -250,12 +253,12 @@ class YoutubeClient implements IYoutubeApi {
                 }
                 throw err
               })
-          ).data?.items
+          ).data?.items ?? []
         : []
 
-      const page = this.mapVideos(nextPage.data.items ?? [], videosDetails ?? [], channel)
+      const page = this.mapVideos(videosPage, videosDetailsPage, channel)
       videos = [...videos, ...page]
-    } while (continuation && videos.length < max)
+    } while (nextPageToken && (limit === undefined || videos.length < limit))
     return videos
   }
 
@@ -329,9 +332,7 @@ class YoutubeClient implements IYoutubeApi {
             }
         )
         // filter out videos that are not public, processed, or have live-stream, since those can't be synced yet
-        .filter(
-          (v) => v.uploadStatus === 'processed' && v.privacyStatus === 'public' && v.liveBroadcastContent === 'none'
-        )
+        .filter((v) => v.uploadStatus === 'processed' && v.liveBroadcastContent === 'none')
     )
   }
 }
@@ -408,7 +409,7 @@ class QuotaTrackingClient implements IYoutubeApi {
     return videos
   }
 
-  async getAllVideos(channel: YtChannel, max: number) {
+  async getAllVideos(channel: YtChannel) {
     // ensure have some left api quota
     if (!(await this.canCallYoutube('sync'))) {
       throw new YoutubeApiError(
@@ -418,7 +419,7 @@ class QuotaTrackingClient implements IYoutubeApi {
     }
 
     // get videos from api
-    const videos = await this.decorated.getAllVideos(channel, max)
+    const videos = await this.decorated.getAllVideos(channel)
 
     // increase used quota count, at least 2 api per channel are being used for requesting video details
     await this.increaseUsedQuota({ syncQuotaIncrement: parseInt((videos.length / 50).toString()) * 2 || 2 })


### PR DESCRIPTION
## Context
As stated in Discord, a creator tried to signup for the YPP, but their onboarding failed

![image](https://github.com/Joystream/youtube-synch/assets/37098720/da6d390e-0aae-4d37-96c7-e53d64d0350d)

## Problem

The issue was that BE was comparing the creation date of only most recent 10 videos, all of which for this channel were uploaded less than a month ago.

Contrary, it should have a comparison that creation date of oldest videos are beyond 30 days.