### PR TITLE
fix: unsupported container issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.4.2
+
+- Add support for transcoding the media files while downloading & merging the audio/video streams from Youtube. E.g, If the media output container is `mkv` then transcode(recode) the media to `mp4`, as `mkv` is not widely supported by the browsers.
+
 ### 1.4.1
 
 - Excludes age restricted videos from syncing.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "youtube-sync",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "license": "MIT",
   "scripts": {
     "postpack": "rm -f oclif.manifest.json",

--- a/src/services/syncProcessing/ContentCreationService.ts
+++ b/src/services/syncProcessing/ContentCreationService.ts
@@ -10,6 +10,8 @@ import { LoggingService } from '../logging'
 import { JoystreamClient } from '../runtime/client'
 import { ContentDownloadService } from './ContentDownloadService'
 
+// TODO: keep hash calculation separate from extrinsic calling
+
 // Video content creation/processing service
 export class ContentCreationService {
   private config: ReadonlyConfig
@@ -33,7 +35,7 @@ export class ContentCreationService {
     this.joystreamClient = joystreamClient
     this.contentDownloadService = contentDownloadService
     this.lastVideoCreationBlockByChannelId = new Map()
-    this.queue = queue({ concurrency: 1, autostart: true, timeout: 60000 /* 1 minute */ })
+    this.queue = queue({ concurrency: 1, autostart: true, timeout: 120000 /* 2 minute */ })
     this.queue.on('error', (err) => {
       this.logger.error(`Got error processing video`, { err })
     })

--- a/src/services/syncProcessing/ContentUploadService.ts
+++ b/src/services/syncProcessing/ContentUploadService.ts
@@ -111,7 +111,7 @@ export class ContentUploadService {
           await this.dynamodbService.videos.updateState(video, 'UploadSucceeded')
 
           // After upload is successful, remove the video file from local storage
-          this.contentDownloadService.removeVideoFile(video.resourceId)
+          await this.contentDownloadService.removeVideoFile(video.resourceId)
 
           this.logger.info(`Successfully uploaded assets for video`, {
             videoId: video.resourceId,

--- a/src/services/youtube/api.ts
+++ b/src/services/youtube/api.ts
@@ -210,6 +210,9 @@ class YoutubeClient implements IYoutubeApi {
     const response = await ytdl(videoUrl, {
       noWarnings: true,
       printJson: true,
+      // If the media output container is `mkv` then transcode (recode) the
+      // media to `mp4`, as `mkv` is not widely supported by the browsers.
+      recodeVideo: 'mkv>mp4',
       format: 'bestvideo[height<=1080]+bestaudio/best[height<=1080]',
       output: `${outPath}/%(id)s.%(ext)s`,
       ffmpegLocation: ffmpegInstaller.path,
@@ -405,7 +408,7 @@ class QuotaTrackingClient implements IYoutubeApi {
     const videos = await this.decorated.getVideos(channel, top)
 
     // increase used quota count, at least 2 api per channel are being used for requesting video details
-    await this.increaseUsedQuota({ syncQuotaIncrement: parseInt((videos.length / 50).toString()) * 2 || 2 })
+    await this.increaseUsedQuota({ syncQuotaIncrement: Math.ceil(videos.length / 50) * 2 || 2 })
 
     return videos
   }
@@ -423,7 +426,7 @@ class QuotaTrackingClient implements IYoutubeApi {
     const videos = await this.decorated.getAllVideos(channel)
 
     // increase used quota count, at least 2 api per channel are being used for requesting video details
-    await this.increaseUsedQuota({ syncQuotaIncrement: parseInt((videos.length / 50).toString()) * 2 || 2 })
+    await this.increaseUsedQuota({ syncQuotaIncrement: Math.ceil(videos.length / 50) * 2 || 2 })
 
     return videos
   }


### PR DESCRIPTION
addresses #197 

## Fix

Now all the `.mkv` container videos are converted to `.mp4` videos after transcoding their audio/video streams. 
Turned out the fix was just adding a configuration option to [yt-dlp](https://github.com/yt-dlp/yt-dlp), as it handles transcoding out of the box.