### PR TITLE
fix: multiple download issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "postpack": "rm -f oclif.manifest.json",
     "prepack": "rm -rf lib && tsc -b && oclif-dev manifest && oclif-dev readme",
-    "build": "tsc --build tsconfig.json && cp -R ./src/infrastructure/pulumi ./lib/infrastructure/pulumi",
+    "build": "rm -rf lib && tsc --build tsconfig.json && cp -R ./src/infrastructure/pulumi ./lib/infrastructure/pulumi",
     "start": "DEPLOYMENT_ENV=dev ./bin/run start",
     "lint": "eslint ./src --ext .ts",
     "start:prod": "./bin/run start",

--- a/src/services/runtime/client.ts
+++ b/src/services/runtime/client.ts
@@ -302,17 +302,10 @@ function getVideoFFProbeMetadata(filePath: string): Promise<VideoFFProbeMetadata
 }
 
 async function getVideoFileMetadata(filePath: string): Promise<VideoFileMetadata> {
-  let ffProbeMetadata: VideoFFProbeMetadata = {}
-  try {
-    ffProbeMetadata = await getVideoFFProbeMetadata(filePath)
-  } catch (e) {
-    const message = e instanceof Error ? e.message : e
-    console.warn(`Failed to get video metadata via ffprobe (${message})`)
-  }
-
   const size = fs.statSync(filePath).size
   const container = path.extname(filePath).slice(1)
   const mimeType = mimeTypes.lookup(container) || `unknown`
+  const ffProbeMetadata = await getVideoFFProbeMetadata(filePath)
   return {
     size,
     container,

--- a/src/services/syncProcessing/ContentCreationService.ts
+++ b/src/services/syncProcessing/ContentCreationService.ts
@@ -75,6 +75,8 @@ export class ContentCreationService {
             ...(await this.dynamodbService.videos.getVideosInState('New')),
           ]
 
+          this.logger.info(`Found ${videos.length} videos with pending on-chain creation.`)
+
           for (const v of videos) {
             const videoFilePath = this.contentDownloadService.getVideoFilePath(v.resourceId)
             if (videoFilePath) {


### PR DESCRIPTION
addresses #197 

based on #198 


There was an issue that the videos which needed to be transcoded (because to unsupported container issue) were downloaded twice. This PR fixes that.