### PR TITLE
YPP: return more context info about channel in '/users' response

### DIFF
--- a/src/services/httpApi/api-spec.json
+++ b/src/services/httpApi/api-spec.json
@@ -1027,11 +1027,31 @@
           },
           "userId": {
             "type": "string"
+          },
+          "channelHandle": {
+            "type": "string"
+          },
+          "channelTitle": {
+            "type": "string"
+          },
+          "channelDescription": {
+            "type": "string"
+          },
+          "avatarUrl": {
+            "type": "string"
+          },
+          "bannerUrl": {
+            "type": "string"
           }
         },
         "required": [
           "email",
-          "userId"
+          "userId",
+          "channelHandle",
+          "channelTitle",
+          "channelDescription",
+          "avatarUrl",
+          "bannerUrl"
         ]
       },
       "Stats": {

--- a/src/services/httpApi/controllers/users.ts
+++ b/src/services/httpApi/controllers/users.ts
@@ -63,7 +63,15 @@ export class UsersController {
       await this.dynamodbService.users.save(user)
 
       // return verified user
-      return { email: user.email, userId: user.id }
+      return {
+        email: user.email,
+        userId: user.id,
+        channelTitle: channel.title,
+        channelDescription: channel.description,
+        avatarUrl: channel.thumbnails.medium,
+        bannerUrl: channel.bannerImageUrl,
+        channelHandle: channel.customUrl,
+      }
     } catch (error) {
       const message = error instanceof Error ? error.message : error
       throw new BadRequestException(message)

--- a/src/services/httpApi/dtos.ts
+++ b/src/services/httpApi/dtos.ts
@@ -101,6 +101,21 @@ export class VerifyChannelResponse {
 
   // ID of the verified user
   @IsString() @ApiProperty({ required: true }) userId: string
+
+  // Youtube Channel/User handle
+  @IsString() @ApiProperty() channelHandle: string
+
+  // Youtube Channel title
+  @IsString() @ApiProperty({ required: true }) channelTitle: string
+
+  // Youtube Channel description
+  @IsString() @ApiProperty({ required: true }) channelDescription: string
+
+  // Youtube Channel avatar URL
+  @IsString() @ApiProperty({ required: true }) avatarUrl: string
+
+  // Youtube Channel banner URL
+  @IsString() @ApiProperty() bannerUrl: string
 }
 
 // Dto for saving the verified Youtube channel

--- a/src/services/youtube/api.ts
+++ b/src/services/youtube/api.ts
@@ -146,7 +146,7 @@ class YoutubeClient implements IYoutubeApi {
 
     const channelResponse = await yt.channels
       .list({
-        part: ['snippet', 'contentDetails', 'statistics'],
+        part: ['snippet', 'contentDetails', 'statistics', 'brandingSettings'],
         mine: true,
       })
       .catch((err) => {
@@ -351,6 +351,7 @@ class YoutubeClient implements IYoutubeApi {
             videoCount: parseInt(channel.statistics?.videoCount ?? '0'),
             commentCount: parseInt(channel.statistics?.commentCount ?? '0'),
           },
+          bannerImageUrl: channel.brandingSettings?.image?.bannerExternalUrl,
           uploadsPlaylistId: channel.contentDetails?.relatedPlaylists?.uploads,
           language: channel.snippet?.defaultLanguage,
           performUnauthorizedSync: false,

--- a/src/types/youtube.ts
+++ b/src/types/youtube.ts
@@ -44,8 +44,11 @@ export class YtChannel {
   // record creation time
   createdAt: Date
 
-  // channel thumbnails
+  // channel Avatar thumbnails
   thumbnails: Thumbnails
+
+  // channel Cover Image URL
+  bannerImageUrl: string
 
   // Channel statistics
   statistics: {


### PR DESCRIPTION
addresses #202 

Updated `/users` POST request API response:

```
{
  "email": "string",
  "userId": "string",
  "channelHandle": "string",
  "channelTitle": "string",
  "channelDescription": "string",
  "avatarUrl": "string",
  "bannerUrl": "string"
}
```