### PR TITLE
fix: Youtube API qouta calculation

### DIFF
--- a/src/services/syncProcessing/YoutubePollingService.ts
+++ b/src/services/syncProcessing/YoutubePollingService.ts
@@ -71,7 +71,7 @@ export class YoutubePollingService {
           `Completed Channels Ingestion. Videos of ${channels.length} channels will be prepared for syncing in this polling cycle....`
         )
 
-        await Promise.all(channels.map((channel) => this.performVideosIngestion(channel)))
+        await Promise.allSettled(channels.map((channel) => this.performVideosIngestion(channel)))
       } catch (err) {
         this.logger.error(`Critical Polling error`, { err })
       }
@@ -83,14 +83,16 @@ export class YoutubePollingService {
    */
   private async performChannelsIngestion(): Promise<YtChannel[]> {
     // get all channels that need to be ingested
-    const channelsToBeIngested = await this.dynamodbService.repo.channels.scan('shouldBeIngested', (s) =>
-      // * Unauthorized channels add by infra operator are exempted from periodic
-      // * ingestion as we don't have access to their access/refresh tokens
-      s.eq(true).and().filter('performUnauthorizedSync').eq(false)
-    )
+    const channelsWithSyncElabled = async () =>
+      await this.dynamodbService.repo.channels.scan('shouldBeIngested', (s) =>
+        // * Unauthorized channels add by infra operator are exempted from periodic
+        // * ingestion as we don't have access to their access/refresh tokens
+        s.eq(true).and().filter('performUnauthorizedSync').eq(false)
+      )
 
-    // updated channel objects with uptodate info (e.g. subscriber count)
+    // updated channel objects with uptodate info
     const updatedChannels: YtChannel[] = []
+    const channelsToBeIngested = await channelsWithSyncElabled()
     for (const ch of channelsToBeIngested) {
       try {
         const uptodateChannel = await this.youtubeApi.getChannel({
@@ -115,7 +117,10 @@ export class YoutubePollingService {
           continue
         }
 
-        updatedChannels.push({ ...ch, statistics: uptodateChannel.statistics })
+        // Update the current channel record if it changed
+        if (!_.isEqual(ch.statistics, uptodateChannel.statistics)) {
+          updatedChannels.push({ ...ch, statistics: uptodateChannel.statistics })
+        }
       } catch (err: unknown) {
         // if app permission is revoked by user from Google account then set `shouldBeIngested` to false & OptOut channel from
         // Ypp program,  because then trying to fetch user channel will throw error with code 400 and 'invalid_grant' message
@@ -151,20 +156,24 @@ export class YoutubePollingService {
     // save updated  channels
     await this.dynamodbService.repo.channels.upsertAll(updatedChannels)
 
-    return updatedChannels.filter((ch) => ch.shouldBeIngested)
+    return channelsWithSyncElabled()
   }
 
   private async performVideosIngestion(channel: YtChannel) {
-    // get all sync-able videos of the channel
-    const allVideosIds = await this.ytdlpClient.getAllVideosIds(channel)
+    try {
+      // get all sync-able videos of the channel
+      const allVideosIds = await this.ytdlpClient.getAllVideosIds(channel)
 
-    // get all new video Ids that are not yet being tracked
-    const newVideosIds = await this.getNewVideosIds(channel, allVideosIds)
+      // get all new video Ids that are not yet being tracked
+      const newVideosIds = await this.getNewVideosIds(channel, allVideosIds)
 
-    //  get all new videos that are not yet being tracked
-    const newVideos = await this.youtubeApi.getVideos(channel, newVideosIds)
+      //  get all new videos that are not yet being tracked
+      const newVideos = await this.youtubeApi.getVideos(channel, newVideosIds)
 
-    // save all new videos to DB including
-    await this.dynamodbService.repo.videos.upsertAll(newVideos)
+      // save all new videos to DB including
+      await this.dynamodbService.repo.videos.upsertAll(newVideos)
+    } catch (err) {
+      this.logger.error('Failed to ingest videos for channel', { err, channelId: channel.joystreamChannelId })
+    }
   }
 }

--- a/src/services/youtube/api.ts
+++ b/src/services/youtube/api.ts
@@ -489,8 +489,8 @@ class QuotaMonitoringClient implements IQuotaMonitoringClient, IYoutubeApi {
     const timeSeries = await this.quotaMonitoringClient?.listTimeSeries(request)
 
     // Get Youtube API quota limit
-    const quotaLimit = (timeSeries![0][0]?.points || [])[0]?.value?.int64Value
-    return Number(quotaLimit)
+    const quotaLimit = Number((timeSeries![0][0]?.points || [])[0]?.value?.int64Value)
+    return _.isFinite(quotaLimit) ? quotaLimit : Number.MAX_SAFE_INTEGER
   }
 
   async getQuotaUsage(): Promise<number> {


### PR DESCRIPTION
IF Youtube API returned non-numeric(i.e. null) value in the quota usage API response, then `YoutubePollingService` was failing to update the state of channels & videos in periodic polling cycle.

This PR fixes the above issue.