### PR TITLE
YPP: fix `yt-dlp` playlist does not exist error

### DIFF
--- a/src/services/youtube/api.ts
+++ b/src/services/youtube/api.ts
@@ -63,11 +63,12 @@ export class YtDlpClient {
 
       return videos
     } catch (err) {
+      if (err instanceof Error && err.message.includes('The playlist does not exist')) {
+        return []
+      }
       throw err
     }
   }
-
-  async a() {}
 }
 
 export interface IYoutubeApi {


### PR DESCRIPTION
addresses #241