### PR TITLE
YPP sync improvements + other minor fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+### 3.2.0
+
+- Optimizes Youtube API quota usage by using `yt-dlp` instead of youtubeApi to fetch the video details
+- add `pendingDownloadTimeoutSec` config option to manage timeout for youtube downloads
+- Add multiple variants to `YtVideo.state.VideoUnavailable`
+- **FIX**: add optional locking feature for Dynamodb tables
+- **FIX**: Only calculate priority for sync-able videos
+
 ### 3.1.0
 
 - bump `@bull-board` npm dependency

--- a/config.yml
+++ b/config.yml
@@ -17,6 +17,7 @@ sync:
     maxConcurrentDownloads: 50
     maxConcurrentUploads: 50
     createVideoTxBatchSize: 10
+    pendingDownloadTimeoutSec: 600 # 10 mins
     storage: 100G
 logs:
   file:

--- a/docs/config/definition-properties-yt-synch-syncronization-related-settings-properties-limits-properties-pendingdownloadtimeoutsec.md
+++ b/docs/config/definition-properties-yt-synch-syncronization-related-settings-properties-limits-properties-pendingdownloadtimeoutsec.md
@@ -1,0 +1,7 @@
+## pendingDownloadTimeoutSec Type
+
+`integer`
+
+## pendingDownloadTimeoutSec Constraints
+
+**minimum**: the value of this number must greater than or equal to: `60`

--- a/docs/config/definition-properties-yt-synch-syncronization-related-settings-properties-limits.md
+++ b/docs/config/definition-properties-yt-synch-syncronization-related-settings-properties-limits.md
@@ -4,13 +4,14 @@
 
 # limits Properties
 
-| Property                                          | Type     | Required | Nullable       | Defined by                                                                                                                                                                                                                                                                                                                        |
-| :------------------------------------------------ | :------- | :------- | :------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [dailyApiQuota](#dailyapiquota)                   | `object` | Required | cannot be null | [Youtube Sync node configuration](definition-properties-yt-synch-syncronization-related-settings-properties-limits-properties-specifies-daily-youtube-api-quota-rationing-scheme-for-youtube-partner-program.md "https://joystream.org/schemas/youtube-synch/config#/properties/sync/properties/limits/properties/dailyApiQuota") |
-| [maxConcurrentDownloads](#maxconcurrentdownloads) | `number` | Required | cannot be null | [Youtube Sync node configuration](definition-properties-yt-synch-syncronization-related-settings-properties-limits-properties-maxconcurrentdownloads.md "https://joystream.org/schemas/youtube-synch/config#/properties/sync/properties/limits/properties/maxConcurrentDownloads")                                                |
-| [createVideoTxBatchSize](#createvideotxbatchsize) | `number` | Required | cannot be null | [Youtube Sync node configuration](definition-properties-yt-synch-syncronization-related-settings-properties-limits-properties-createvideotxbatchsize.md "https://joystream.org/schemas/youtube-synch/config#/properties/sync/properties/limits/properties/createVideoTxBatchSize")                                                |
-| [maxConcurrentUploads](#maxconcurrentuploads)     | `number` | Required | cannot be null | [Youtube Sync node configuration](definition-properties-yt-synch-syncronization-related-settings-properties-limits-properties-maxconcurrentuploads.md "https://joystream.org/schemas/youtube-synch/config#/properties/sync/properties/limits/properties/maxConcurrentUploads")                                                    |
-| [storage](#storage)                               | `string` | Required | cannot be null | [Youtube Sync node configuration](definition-properties-yt-synch-syncronization-related-settings-properties-limits-properties-storage.md "https://joystream.org/schemas/youtube-synch/config#/properties/sync/properties/limits/properties/storage")                                                                              |
+| Property                                                | Type      | Required | Nullable       | Defined by                                                                                                                                                                                                                                                                                                                        |
+| :------------------------------------------------------ | :-------- | :------- | :------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [dailyApiQuota](#dailyapiquota)                         | `object`  | Required | cannot be null | [Youtube Sync node configuration](definition-properties-yt-synch-syncronization-related-settings-properties-limits-properties-specifies-daily-youtube-api-quota-rationing-scheme-for-youtube-partner-program.md 'https://joystream.org/schemas/youtube-synch/config#/properties/sync/properties/limits/properties/dailyApiQuota') |
+| [maxConcurrentDownloads](#maxconcurrentdownloads)       | `number`  | Required | cannot be null | [Youtube Sync node configuration](definition-properties-yt-synch-syncronization-related-settings-properties-limits-properties-maxconcurrentdownloads.md 'https://joystream.org/schemas/youtube-synch/config#/properties/sync/properties/limits/properties/maxConcurrentDownloads')                                                |
+| [createVideoTxBatchSize](#createvideotxbatchsize)       | `number`  | Required | cannot be null | [Youtube Sync node configuration](definition-properties-yt-synch-syncronization-related-settings-properties-limits-properties-createvideotxbatchsize.md 'https://joystream.org/schemas/youtube-synch/config#/properties/sync/properties/limits/properties/createVideoTxBatchSize')                                                |
+| [maxConcurrentUploads](#maxconcurrentuploads)           | `number`  | Required | cannot be null | [Youtube Sync node configuration](definition-properties-yt-synch-syncronization-related-settings-properties-limits-properties-maxconcurrentuploads.md 'https://joystream.org/schemas/youtube-synch/config#/properties/sync/properties/limits/properties/maxConcurrentUploads')                                                    |
+| [pendingDownloadTimeoutSec](#pendingdownloadtimeoutsec) | `integer` | Required | cannot be null | [Youtube Sync node configuration](definition-properties-yt-synch-syncronization-related-settings-properties-limits-properties-pendingdownloadtimeoutsec.md 'https://joystream.org/schemas/youtube-synch/config#/properties/sync/properties/limits/properties/pendingDownloadTimeoutSec')                                          |
+| [storage](#storage)                                     | `string`  | Required | cannot be null | [Youtube Sync node configuration](definition-properties-yt-synch-syncronization-related-settings-properties-limits-properties-storage.md 'https://joystream.org/schemas/youtube-synch/config#/properties/sync/properties/limits/properties/storage')                                                                              |
 
 ## dailyApiQuota
 
@@ -18,13 +19,13 @@ Specifies daily Youtube API quota rationing scheme for Youtube Partner Program
 
 `dailyApiQuota`
 
-*   is required
+- is required
 
-*   Type: `object` ([Specifies daily Youtube API quota rationing scheme for Youtube Partner Program](definition-properties-yt-synch-syncronization-related-settings-properties-limits-properties-specifies-daily-youtube-api-quota-rationing-scheme-for-youtube-partner-program.md))
+- Type: `object` ([Specifies daily Youtube API quota rationing scheme for Youtube Partner Program](definition-properties-yt-synch-syncronization-related-settings-properties-limits-properties-specifies-daily-youtube-api-quota-rationing-scheme-for-youtube-partner-program.md))
 
-*   cannot be null
+- cannot be null
 
-*   defined in: [Youtube Sync node configuration](definition-properties-yt-synch-syncronization-related-settings-properties-limits-properties-specifies-daily-youtube-api-quota-rationing-scheme-for-youtube-partner-program.md "https://joystream.org/schemas/youtube-synch/config#/properties/sync/properties/limits/properties/dailyApiQuota")
+- defined in: [Youtube Sync node configuration](definition-properties-yt-synch-syncronization-related-settings-properties-limits-properties-specifies-daily-youtube-api-quota-rationing-scheme-for-youtube-partner-program.md 'https://joystream.org/schemas/youtube-synch/config#/properties/sync/properties/limits/properties/dailyApiQuota')
 
 ### dailyApiQuota Type
 
@@ -36,13 +37,13 @@ Max no. of videos that should be concurrently downloaded from Youtube to be prep
 
 `maxConcurrentDownloads`
 
-*   is required
+- is required
 
-*   Type: `number`
+- Type: `number`
 
-*   cannot be null
+- cannot be null
 
-*   defined in: [Youtube Sync node configuration](definition-properties-yt-synch-syncronization-related-settings-properties-limits-properties-maxconcurrentdownloads.md "https://joystream.org/schemas/youtube-synch/config#/properties/sync/properties/limits/properties/maxConcurrentDownloads")
+- defined in: [Youtube Sync node configuration](definition-properties-yt-synch-syncronization-related-settings-properties-limits-properties-maxconcurrentdownloads.md 'https://joystream.org/schemas/youtube-synch/config#/properties/sync/properties/limits/properties/maxConcurrentDownloads')
 
 ### maxConcurrentDownloads Type
 
@@ -62,13 +63,13 @@ No. of videos that should be created in a batched 'create_video' tx
 
 `createVideoTxBatchSize`
 
-*   is required
+- is required
 
-*   Type: `number`
+- Type: `number`
 
-*   cannot be null
+- cannot be null
 
-*   defined in: [Youtube Sync node configuration](definition-properties-yt-synch-syncronization-related-settings-properties-limits-properties-createvideotxbatchsize.md "https://joystream.org/schemas/youtube-synch/config#/properties/sync/properties/limits/properties/createVideoTxBatchSize")
+- defined in: [Youtube Sync node configuration](definition-properties-yt-synch-syncronization-related-settings-properties-limits-properties-createvideotxbatchsize.md 'https://joystream.org/schemas/youtube-synch/config#/properties/sync/properties/limits/properties/createVideoTxBatchSize')
 
 ### createVideoTxBatchSize Type
 
@@ -88,13 +89,13 @@ Max no. of videos that should be concurrently uploaded to Joystream's storage no
 
 `maxConcurrentUploads`
 
-*   is required
+- is required
 
-*   Type: `number`
+- Type: `number`
 
-*   cannot be null
+- cannot be null
 
-*   defined in: [Youtube Sync node configuration](definition-properties-yt-synch-syncronization-related-settings-properties-limits-properties-maxconcurrentuploads.md "https://joystream.org/schemas/youtube-synch/config#/properties/sync/properties/limits/properties/maxConcurrentUploads")
+- defined in: [Youtube Sync node configuration](definition-properties-yt-synch-syncronization-related-settings-properties-limits-properties-maxconcurrentuploads.md 'https://joystream.org/schemas/youtube-synch/config#/properties/sync/properties/limits/properties/maxConcurrentUploads')
 
 ### maxConcurrentUploads Type
 
@@ -108,19 +109,41 @@ The default value is:
 50
 ```
 
+## pendingDownloadTimeoutSec
+
+Timeout for pending youtube video downloads in seconds
+
+`pendingDownloadTimeoutSec`
+
+- is required
+
+- Type: `integer`
+
+- cannot be null
+
+- defined in: [Youtube Sync node configuration](definition-properties-yt-synch-syncronization-related-settings-properties-limits-properties-pendingdownloadtimeoutsec.md 'https://joystream.org/schemas/youtube-synch/config#/properties/sync/properties/limits/properties/pendingDownloadTimeoutSec')
+
+### pendingDownloadTimeoutSec Type
+
+`integer`
+
+### pendingDownloadTimeoutSec Constraints
+
+**minimum**: the value of this number must greater than or equal to: `60`
+
 ## storage
 
 Maximum total size of all downloaded assets stored in `downloadsDir`
 
 `storage`
 
-*   is required
+- is required
 
-*   Type: `string`
+- Type: `string`
 
-*   cannot be null
+- cannot be null
 
-*   defined in: [Youtube Sync node configuration](definition-properties-yt-synch-syncronization-related-settings-properties-limits-properties-storage.md "https://joystream.org/schemas/youtube-synch/config#/properties/sync/properties/limits/properties/storage")
+- defined in: [Youtube Sync node configuration](definition-properties-yt-synch-syncronization-related-settings-properties-limits-properties-storage.md 'https://joystream.org/schemas/youtube-synch/config#/properties/sync/properties/limits/properties/storage')
 
 ### storage Type
 
@@ -128,10 +151,10 @@ Maximum total size of all downloaded assets stored in `downloadsDir`
 
 ### storage Constraints
 
-**pattern**: the string must match the following regular expression: 
+**pattern**: the string must match the following regular expression:
 
 ```regexp
 ^[0-9]+(B|K|M|G|T)$
 ```
 
-[try pattern](https://regexr.com/?expression=%5E%5B0-9%5D%2B\(B%7CK%7CM%7CG%7CT\)%24 "try regular expression with regexr.com")
+[try pattern](<https://regexr.com/?expression=%5E%5B0-9%5D%2B(B%7CK%7CM%7CG%7CT)%24> 'try regular expression with regexr.com')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "youtube-sync",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "license": "MIT",
   "scripts": {
     "postpack": "rm -f oclif.manifest.json",

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -48,6 +48,7 @@ export class Service {
         this.logging,
         this.dynamodbService,
         this.youtubeApi,
+        this.runtimeApi,
         this.joystreamClient,
         this.queryNodeApi
       )

--- a/src/repository/user.ts
+++ b/src/repository/user.ts
@@ -74,9 +74,19 @@ export class UsersRepository implements IRepository<YtUser> {
   // lock any updates on video table
   private readonly ASYNC_LOCK_ID = 'user'
   private asyncLock: AsyncLock = new AsyncLock({ maxPending: Number.MAX_SAFE_INTEGER })
+  private useLock: boolean // Flag to determine if locking should be used
 
-  constructor(tablePrefix: ResourcePrefix) {
+  constructor(tablePrefix: ResourcePrefix, useLock: boolean = true) {
     this.model = createUserModel(tablePrefix)
+    this.useLock = useLock
+  }
+
+  private async withLock<T>(func: () => Promise<T>): Promise<T> {
+    if (this.useLock) {
+      return this.asyncLock.acquire(this.ASYNC_LOCK_ID, func)
+    } else {
+      return func()
+    }
   }
 
   async upsertAll(users: YtUser[]): Promise<YtUser[]> {
@@ -85,7 +95,7 @@ export class UsersRepository implements IRepository<YtUser> {
   }
 
   async scan(init: ConditionInitializer, f: (q: Scan<AnyItem>) => Scan<AnyItem>): Promise<YtUser[]> {
-    return this.asyncLock.acquire(this.ASYNC_LOCK_ID, async () => {
+    return this.withLock(async () => {
       let lastKey = undefined
       const results = []
       do {
@@ -101,14 +111,14 @@ export class UsersRepository implements IRepository<YtUser> {
   }
 
   async get(id: string): Promise<YtUser | undefined> {
-    return this.asyncLock.acquire(this.ASYNC_LOCK_ID, async () => {
+    return this.withLock(async () => {
       const result = await this.model.get({ id })
       return result ? mapTo<YtUser>(result) : undefined
     })
   }
 
   async save(user: YtUser): Promise<YtUser> {
-    return this.asyncLock.acquire(this.ASYNC_LOCK_ID, async () => {
+    return this.withLock(async () => {
       const update = omit(['id', 'updatedAt'], user)
       const result = await this.model.update({ id: user.id }, update)
       return mapTo<YtUser>(result)
@@ -116,14 +126,14 @@ export class UsersRepository implements IRepository<YtUser> {
   }
 
   async delete(id: string): Promise<void> {
-    return this.asyncLock.acquire(this.ASYNC_LOCK_ID, async () => {
+    return this.withLock(async () => {
       await this.model.delete({ id })
       return
     })
   }
 
   async query(init: ConditionInitializer, f: (q: Query<AnyItem>) => Query<AnyItem>) {
-    return this.asyncLock.acquire(this.ASYNC_LOCK_ID, async () => {
+    return this.withLock(async () => {
       let lastKey = undefined
       const results = []
       do {

--- a/src/repository/video.ts
+++ b/src/repository/video.ts
@@ -31,6 +31,9 @@ function videoRepository(tablePrefix: ResourcePrefix) {
       // Video's description
       description: String,
 
+      // Video's playlist ID
+      playlistId: String,
+
       viewCount: Number,
 
       thumbnails: {
@@ -63,6 +66,9 @@ function videoRepository(tablePrefix: ResourcePrefix) {
 
       // video duration in seconds
       duration: Number,
+
+      // The status of the uploaded video on Youtube.
+      uploadStatus: String,
 
       // The privacy status of the youtube
       privacyStatus: String,

--- a/src/repository/video.ts
+++ b/src/repository/video.ts
@@ -31,9 +31,6 @@ function videoRepository(tablePrefix: ResourcePrefix) {
       // Video's description
       description: String,
 
-      // Video's playlist ID
-      playlistId: String,
-
       viewCount: Number,
 
       thumbnails: {
@@ -67,9 +64,6 @@ function videoRepository(tablePrefix: ResourcePrefix) {
       // video duration in seconds
       duration: Number,
 
-      // The status of the uploaded video on Youtube.
-      uploadStatus: String,
-
       // The privacy status of the youtube
       privacyStatus: String,
 
@@ -94,9 +88,6 @@ function videoRepository(tablePrefix: ResourcePrefix) {
           },
         },
       },
-
-      // ID of the corresponding Joystream Channel (De-normalized from Channel table)
-      joystreamChannelId: Number,
 
       // Video creation date on youtube
       publishedAt: String,

--- a/src/schemas/config.ts
+++ b/src/schemas/config.ts
@@ -329,6 +329,11 @@ export const configSchema: JSONSchema7 = objectSchema({
               type: 'number',
               default: 50,
             },
+            pendingDownloadTimeoutSec: {
+              description: 'Timeout for pending youtube video downloads in seconds',
+              type: 'integer',
+              minimum: 60,
+            },
             storage: {
               description: 'Maximum total size of all downloaded assets stored in `downloadsDir`',
               type: 'string',
@@ -340,6 +345,7 @@ export const configSchema: JSONSchema7 = objectSchema({
             'maxConcurrentDownloads',
             'createVideoTxBatchSize',
             'maxConcurrentUploads',
+            'pendingDownloadTimeoutSec',
             'storage',
           ],
         }),

--- a/src/services/httpApi/controllers/channels.ts
+++ b/src/services/httpApi/controllers/channels.ts
@@ -100,7 +100,7 @@ export class ChannelsController {
       }
 
       // get channel from user
-      const { channel } = await this.youtubeApi.getVerifiedChannel(user)
+      const channel = await this.youtubeApi.getChannel(user)
 
       // reset authorization code to prevent repeated save channel requests by authorization code re-use
       const updatedUser: YtUser = { ...user, email, authorizationCode: randomBytes(10).toString('hex') }

--- a/src/services/syncProcessing/YoutubePollingService.ts
+++ b/src/services/syncProcessing/YoutubePollingService.ts
@@ -190,7 +190,7 @@ export class YoutubePollingService {
       const historicalVideosCountLimit = YtChannel.videoCap(channel)
 
       // get iDs of all sync-able videos within the channel limits
-      const videosIds = await this.youtubeApi.ytdlpClient.getVideos(channel, historicalVideosCountLimit)
+      const videosIds = await this.youtubeApi.ytdlpClient.getVideosIDs(channel, historicalVideosCountLimit)
 
       // get all video Ids that are not yet being tracked
       let untrackedVideosIds = await this.getUntrackedVideosIds(channel, videosIds)
@@ -201,7 +201,7 @@ export class YoutubePollingService {
       }
 
       //  get all videos that are not yet being tracked
-      const untrackedVideos = await this.youtubeApi.getVideos(
+      const untrackedVideos = await this.youtubeApi.ytdlpClient.getVideos(
         channel,
         untrackedVideosIds.map((v) => v.id)
       )

--- a/src/services/syncProcessing/index.ts
+++ b/src/services/syncProcessing/index.ts
@@ -8,6 +8,7 @@ import { ReadonlyConfig } from '../../types'
 import { ChannelSyncStatus, YtChannel, YtVideo } from '../../types/youtube'
 import { LoggingService } from '../logging'
 import { QueryNodeApi } from '../query-node/api'
+import { RuntimeApi } from '../runtime/api'
 import { JoystreamClient } from '../runtime/client'
 import { IYoutubeApi } from '../youtube/api'
 import { ContentCreationService } from './ContentCreationService'
@@ -32,16 +33,17 @@ export class ContentProcessingService {
     logging: LoggingService,
     private dynamodbService: DynamodbService,
     youtubeApi: IYoutubeApi,
+    runtimeApi: RuntimeApi,
     private joystreamClient: JoystreamClient,
     queryNodeApi: QueryNodeApi
   ) {
     this.logger = logging.createLogger('ContentProcessingService')
     this.jobsManager = new JobsFlowManager(this.config.redis)
 
-    this.contentDownloadService = new ContentDownloadService(config, logging, this.dynamodbService, youtubeApi)
+    this.contentDownloadService = new ContentDownloadService(config, logging, dynamodbService, youtubeApi)
     this.contentMetadataService = new ContentMetadataService(logging)
-    this.contentCreationService = new ContentCreationService(logging, this.dynamodbService, this.joystreamClient)
-    this.contentUploadService = new ContentUploadService(logging, this.dynamodbService, queryNodeApi)
+    this.contentCreationService = new ContentCreationService(logging, dynamodbService, joystreamClient)
+    this.contentUploadService = new ContentUploadService(logging, dynamodbService, runtimeApi, queryNodeApi)
 
     // create job queues
 

--- a/src/services/syncProcessing/index.ts
+++ b/src/services/syncProcessing/index.ts
@@ -133,21 +133,21 @@ export class ContentProcessingService {
       allUnsyncedVideosByChannelId.map(async ({ channelId, unsyncedVideos }) => {
         const channel = await this.dynamodbService.channels.getById(channelId)
         const totalVideos = YtChannel.totalVideos(channel)
-        const percentageOfCreatorBacklogNotSynched = (unsyncedVideos.length * 100) / totalVideos
+        const percentageOfCreatorBacklogNotSynched = (unsyncedVideos.length * 100) / (totalVideos || 1)
 
         for (const video of unsyncedVideos) {
-          let sudoPriority = SyncUtils.DEFAULT_SUDO_PRIORITY
-          if (new Date(video.publishedAt) > channel.createdAt && video.duration > 300) {
-            sudoPriority += 50
-          }
-
-          const priority = SyncUtils.calculateJobPriority(
-            sudoPriority,
-            percentageOfCreatorBacklogNotSynched,
-            Date.parse(video.publishedAt)
-          )
-
           if ((await this.ensureVideoCanBeProcessed(video, channel)) && !(await this.isActiveJobFlow(video.id))) {
+            let sudoPriority = SyncUtils.DEFAULT_SUDO_PRIORITY
+            if (new Date(video.publishedAt) > channel.createdAt && video.duration > 300) {
+              sudoPriority += 50
+            }
+
+            const priority = SyncUtils.calculateJobPriority(
+              sudoPriority,
+              percentageOfCreatorBacklogNotSynched,
+              Date.parse(video.publishedAt)
+            )
+
             // create new job flow
             const flowJob = this.createFlow(video, priority)
 

--- a/src/types/generated/ConfigJson.d.ts
+++ b/src/types/generated/ConfigJson.d.ts
@@ -274,6 +274,10 @@ export interface YTSynchSyncronizationRelatedSettings {
      */
     maxConcurrentUploads: number
     /**
+     * Timeout for pending youtube video downloads in seconds
+     */
+    pendingDownloadTimeoutSec: number
+    /**
      * Maximum total size of all downloaded assets stored in `downloadsDir`
      */
     storage: string

--- a/src/types/youtube.ts
+++ b/src/types/youtube.ts
@@ -263,9 +263,6 @@ export class YtVideo {
   // Video description
   description: string
 
-  // Video's playlist ID
-  playlistId: string
-
   // video views count
   viewCount: number
 
@@ -363,6 +360,28 @@ export type YtDlpFlatPlaylistOutput = {
   id: string
   publishedAt: Date
 }[]
+
+export type YtDlpVideoOutput = {
+  id: string
+  channel_id: string
+  title: string
+  language: string
+  upload_date: string
+  filesize_approx: number
+  description: string
+  duration: number
+  view_count: number
+  like_count: number
+  comment_count: number
+  live_status: 'not_live' | 'is_live' | 'is_upcoming' | 'was_live' | 'post_live'
+  original_url: string
+  availability: 'public' | 'private' | 'unlisted'
+  license: 'Creative Commons Attribution license (reuse allowed)' | undefined
+  ext: string
+  thumbnails: {
+    url: string
+  }[]
+}
 
 export type FaucetRegisterMembershipParams = {
   account: string

--- a/src/types/youtube.ts
+++ b/src/types/youtube.ts
@@ -194,23 +194,25 @@ export type Thumbnails = {
   standard: string
 }
 
-export enum VideoStates {
-  New = 1,
-  // `create_video` extrinsic errored
-  VideoCreationFailed = 2,
-  // Video is being creating on Joystream network (by calling extrinsics, but not yet uploaded)
-  CreatingVideo = 3,
-  // Video has been created on Joystream network (by calling extrinsics, but not yet uploaded)
-  VideoCreated = 4,
-  // Video upload to Joystream failed
-  UploadFailed = 5,
-  // Video is being uploaded to Joystream
-  UploadStarted = 6,
-  // Video upload to Joystream succeeded
-  UploadSucceeded = 7,
-  // Video was deleted from Youtube or set to private after being tracked by
-  // YT-synch service or skipped from syncing by the YT-synch service itself.
-  VideoUnavailable = 8,
+export enum VideoUnavailableReasons {
+  Deleted = 'Deleted',
+  Private = 'Private',
+  Skipped = 'Skipped',
+  Other = 'Other',
+  Unavailable = 'Unavailable',
+  PostprocessingError = 'PostprocessingError',
+  EmptyDownload = 'EmptyDownload',
+}
+
+// Modify the VideoStates enum to include a template literal type for the VideoUnavailable variant
+enum VideoStates {
+  New = 'New',
+  VideoCreationFailed = 'VideoCreationFailed',
+  CreatingVideo = 'CreatingVideo',
+  VideoCreated = 'VideoCreated',
+  UploadFailed = 'UploadFailed',
+  UploadStarted = 'UploadStarted',
+  UploadSucceeded = 'UploadSucceeded',
 }
 
 export enum ChannelYppStatusVerified {
@@ -231,11 +233,15 @@ export const verifiedVariants = Object.values(ChannelYppStatusVerified).map((sta
 const suspendedVariants = Object.values(ChannelYppStatusSuspended).map((status) => `Suspended::${status}` as const)
 const readonlyChannelYppStatus = ['Unverified', ...verifiedVariants, ...suspendedVariants, 'OptedOut'] as const
 
-export const videoStates = Object.keys(VideoStates).filter((v) => isNaN(Number(v)))
+export const videoUnavailableVariants = Object.values(VideoUnavailableReasons).map(
+  (reason) => `VideoUnavailable::${reason}` as const
+)
+
+export const videoStates = [...(Object.keys(VideoStates) as (keyof typeof VideoStates)[]), ...videoUnavailableVariants]
 
 export const channelYppStatus = readonlyChannelYppStatus as unknown as string[]
 
-export type VideoState = keyof typeof VideoStates
+export type VideoState = typeof videoStates[number]
 
 export type ChannelYppStatus = typeof readonlyChannelYppStatus[number]
 


### PR DESCRIPTION
This PR: 

- addresses #274 by using `yt-dlp` instead of youtubeApi to fetch the video details
- [Add multiple variants to YtVideo.state.VideoUnavailable](https://github.com/Joystream/youtube-synch/commit/d1d15f5b4f126d7c51f47437ff9ba4476cd22edc)
- [add 'pendingDownloadTimeoutSec' config option to manage timeout for youtube downloads](https://github.com/Joystream/youtube-synch/commit/786f0cfec391128a7292630da15629f5461705e3) 