### PR TITLE
Release: `v3.2.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+### 3.3.0
+
+- Added `chisel` proxy setup with automated IP rotation mechanism to circumvent youtube IP blockage, also integrated proxy setup with yt-synch server. See [docs](socks5-proxy/SETUP.md) for more details
+- Optimizes Youtube API quota usage by using `yt-dlp` instead of youtubeApi to fetch the channel details
+- Added `processedAt` in channels schema to track the timestamp when channel was processed (`Verified`/`Suspended`)
+- Removed unused method from video repository
+- Added YPP InductionRequirement of `CHANNEL_CRITERIA_UNMET_CREATION_DATE`
+- Update video processing priority calculation to prioritize Silver+ tier channels
+- **FIX**: Update referral reward values
+- **FIX**: Added error handling for winston logger
+- **FIX**: Remove stale downloaded videos
+- **FIX**: Avoid updating some channel properties e.g. `createdAt`, `email`, `userId` on re-signup
+
 ### 3.2.0
 
 - Optimizes Youtube API quota usage by using `yt-dlp` instead of youtubeApi to fetch the video details

--- a/config.yml
+++ b/config.yml
@@ -38,6 +38,10 @@ youtube:
   clientSecret: google-client-secret
   # adcKeyFilePath: path/to/adc-key-file.json
   # maxAllowedQuotaUsageInPercentage: 95
+proxy:
+  url: socks5://chisel-client:1080
+  chiselProxy:
+    ec2AutoRotateIp: false
 aws:
   endpoint: http://localhost:4566
   region: us-east-1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,12 +43,16 @@ services:
       # YT_SYNCH__JOYSTREAM__FAUCET__CAPTCHA_BYPASS_KEY: ${YT_SYNCH__JOYSTREAM__FAUCET__CAPTCHA_BYPASS_KEY}
     ports:
       - 127.0.0.1:${YT_SYNCH__HTTP_API__PORT}:${YT_SYNCH__HTTP_API__PORT}
+    networks:
+      - youtube-synch
   redis:
     image: redis:7.2.1
     container_name: redis
     command: [ "redis-server", "--maxmemory-policy", "noeviction" ]
     ports:
       - 127.0.0.1:${YT_SYNCH__ENDPOINTS__REDIS__PORT}:${YT_SYNCH__ENDPOINTS__REDIS__PORT}
+    networks:
+      - youtube-synch
     volumes:
       - redis-data:/data
 
@@ -59,3 +63,7 @@ volumes:
     driver: local
   redis-data:
     driver: local
+
+networks:
+  youtube-synch:
+    name: youtube-synch

--- a/docs/config/definition-properties-socks5-proxy-client-configuration-used-by-yt-dlp-to-bypass-ip-blockage-by-youtube-dependencies.md
+++ b/docs/config/definition-properties-socks5-proxy-client-configuration-used-by-yt-dlp-to-bypass-ip-blockage-by-youtube-dependencies.md
@@ -1,0 +1,3 @@
+## dependencies Type
+
+unknown

--- a/docs/config/definition-properties-socks5-proxy-client-configuration-used-by-yt-dlp-to-bypass-ip-blockage-by-youtube-properties-chiselproxy-properties-ec2autorotateip.md
+++ b/docs/config/definition-properties-socks5-proxy-client-configuration-used-by-yt-dlp-to-bypass-ip-blockage-by-youtube-properties-chiselproxy-properties-ec2autorotateip.md
@@ -1,0 +1,3 @@
+## ec2AutoRotateIp Type
+
+`boolean`

--- a/docs/config/definition-properties-socks5-proxy-client-configuration-used-by-yt-dlp-to-bypass-ip-blockage-by-youtube-properties-chiselproxy.md
+++ b/docs/config/definition-properties-socks5-proxy-client-configuration-used-by-yt-dlp-to-bypass-ip-blockage-by-youtube-properties-chiselproxy.md
@@ -1,0 +1,27 @@
+## chiselProxy Type
+
+`object` ([Details](definition-properties-socks5-proxy-client-configuration-used-by-yt-dlp-to-bypass-ip-blockage-by-youtube-properties-chiselproxy.md))
+
+# chiselProxy Properties
+
+| Property                            | Type      | Required | Nullable       | Defined by                                                                                                                                                                                                                                                                                                               |
+| :---------------------------------- | :-------- | :------- | :------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [ec2AutoRotateIp](#ec2autorotateip) | `boolean` | Optional | cannot be null | [Youtube Sync node configuration](definition-properties-socks5-proxy-client-configuration-used-by-yt-dlp-to-bypass-ip-blockage-by-youtube-properties-chiselproxy-properties-ec2autorotateip.md "https://joystream.org/schemas/youtube-synch/config#/properties/proxy/properties/chiselProxy/properties/ec2AutoRotateIp") |
+
+## ec2AutoRotateIp
+
+Boolean option to enable auto rotation of ec2 instance IP where chisel server is running by restating it
+
+`ec2AutoRotateIp`
+
+*   is optional
+
+*   Type: `boolean`
+
+*   cannot be null
+
+*   defined in: [Youtube Sync node configuration](definition-properties-socks5-proxy-client-configuration-used-by-yt-dlp-to-bypass-ip-blockage-by-youtube-properties-chiselproxy-properties-ec2autorotateip.md "https://joystream.org/schemas/youtube-synch/config#/properties/proxy/properties/chiselProxy/properties/ec2AutoRotateIp")
+
+### ec2AutoRotateIp Type
+
+`boolean`

--- a/docs/config/definition-properties-socks5-proxy-client-configuration-used-by-yt-dlp-to-bypass-ip-blockage-by-youtube-properties-url.md
+++ b/docs/config/definition-properties-socks5-proxy-client-configuration-used-by-yt-dlp-to-bypass-ip-blockage-by-youtube-properties-url.md
@@ -1,0 +1,3 @@
+## url Type
+
+`string`

--- a/docs/config/definition-properties-socks5-proxy-client-configuration-used-by-yt-dlp-to-bypass-ip-blockage-by-youtube.md
+++ b/docs/config/definition-properties-socks5-proxy-client-configuration-used-by-yt-dlp-to-bypass-ip-blockage-by-youtube.md
@@ -1,0 +1,46 @@
+## proxy Type
+
+`object` ([Socks5 proxy client configuration used by yt-dlp to bypass IP blockage by Youtube](definition-properties-socks5-proxy-client-configuration-used-by-yt-dlp-to-bypass-ip-blockage-by-youtube.md))
+
+# proxy Properties
+
+| Property                    | Type     | Required | Nullable       | Defined by                                                                                                                                                                                                                                                         |
+| :-------------------------- | :------- | :------- | :------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [url](#url)                 | `string` | Optional | cannot be null | [Youtube Sync node configuration](definition-properties-socks5-proxy-client-configuration-used-by-yt-dlp-to-bypass-ip-blockage-by-youtube-properties-url.md "https://joystream.org/schemas/youtube-synch/config#/properties/proxy/properties/url")                 |
+| [chiselProxy](#chiselproxy) | `object` | Optional | cannot be null | [Youtube Sync node configuration](definition-properties-socks5-proxy-client-configuration-used-by-yt-dlp-to-bypass-ip-blockage-by-youtube-properties-chiselproxy.md "https://joystream.org/schemas/youtube-synch/config#/properties/proxy/properties/chiselProxy") |
+
+## url
+
+Proxy Client URL e.g. socks\://localhost:1080, socks\://user:password\@localhost:1080
+
+`url`
+
+*   is optional
+
+*   Type: `string`
+
+*   cannot be null
+
+*   defined in: [Youtube Sync node configuration](definition-properties-socks5-proxy-client-configuration-used-by-yt-dlp-to-bypass-ip-blockage-by-youtube-properties-url.md "https://joystream.org/schemas/youtube-synch/config#/properties/proxy/properties/url")
+
+### url Type
+
+`string`
+
+## chiselProxy
+
+Configuration option to manage Chisel Client & Server. Before enabling this option please refer to setup guide in `socks5-proxy/SETUP.md`
+
+`chiselProxy`
+
+*   is optional
+
+*   Type: `object` ([Details](definition-properties-socks5-proxy-client-configuration-used-by-yt-dlp-to-bypass-ip-blockage-by-youtube-properties-chiselproxy.md))
+
+*   cannot be null
+
+*   defined in: [Youtube Sync node configuration](definition-properties-socks5-proxy-client-configuration-used-by-yt-dlp-to-bypass-ip-blockage-by-youtube-properties-chiselproxy.md "https://joystream.org/schemas/youtube-synch/config#/properties/proxy/properties/chiselProxy")
+
+### chiselProxy Type
+
+`object` ([Details](definition-properties-socks5-proxy-client-configuration-used-by-yt-dlp-to-bypass-ip-blockage-by-youtube-properties-chiselproxy.md))

--- a/docs/config/definition-properties-yt-synch-syncronization-related-settings-properties-limits.md
+++ b/docs/config/definition-properties-yt-synch-syncronization-related-settings-properties-limits.md
@@ -6,12 +6,12 @@
 
 | Property                                                | Type      | Required | Nullable       | Defined by                                                                                                                                                                                                                                                                                                                        |
 | :------------------------------------------------------ | :-------- | :------- | :------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [dailyApiQuota](#dailyapiquota)                         | `object`  | Required | cannot be null | [Youtube Sync node configuration](definition-properties-yt-synch-syncronization-related-settings-properties-limits-properties-specifies-daily-youtube-api-quota-rationing-scheme-for-youtube-partner-program.md 'https://joystream.org/schemas/youtube-synch/config#/properties/sync/properties/limits/properties/dailyApiQuota') |
-| [maxConcurrentDownloads](#maxconcurrentdownloads)       | `number`  | Required | cannot be null | [Youtube Sync node configuration](definition-properties-yt-synch-syncronization-related-settings-properties-limits-properties-maxconcurrentdownloads.md 'https://joystream.org/schemas/youtube-synch/config#/properties/sync/properties/limits/properties/maxConcurrentDownloads')                                                |
-| [createVideoTxBatchSize](#createvideotxbatchsize)       | `number`  | Required | cannot be null | [Youtube Sync node configuration](definition-properties-yt-synch-syncronization-related-settings-properties-limits-properties-createvideotxbatchsize.md 'https://joystream.org/schemas/youtube-synch/config#/properties/sync/properties/limits/properties/createVideoTxBatchSize')                                                |
-| [maxConcurrentUploads](#maxconcurrentuploads)           | `number`  | Required | cannot be null | [Youtube Sync node configuration](definition-properties-yt-synch-syncronization-related-settings-properties-limits-properties-maxconcurrentuploads.md 'https://joystream.org/schemas/youtube-synch/config#/properties/sync/properties/limits/properties/maxConcurrentUploads')                                                    |
-| [pendingDownloadTimeoutSec](#pendingdownloadtimeoutsec) | `integer` | Required | cannot be null | [Youtube Sync node configuration](definition-properties-yt-synch-syncronization-related-settings-properties-limits-properties-pendingdownloadtimeoutsec.md 'https://joystream.org/schemas/youtube-synch/config#/properties/sync/properties/limits/properties/pendingDownloadTimeoutSec')                                          |
-| [storage](#storage)                                     | `string`  | Required | cannot be null | [Youtube Sync node configuration](definition-properties-yt-synch-syncronization-related-settings-properties-limits-properties-storage.md 'https://joystream.org/schemas/youtube-synch/config#/properties/sync/properties/limits/properties/storage')                                                                              |
+| [dailyApiQuota](#dailyapiquota)                         | `object`  | Required | cannot be null | [Youtube Sync node configuration](definition-properties-yt-synch-syncronization-related-settings-properties-limits-properties-specifies-daily-youtube-api-quota-rationing-scheme-for-youtube-partner-program.md "https://joystream.org/schemas/youtube-synch/config#/properties/sync/properties/limits/properties/dailyApiQuota") |
+| [maxConcurrentDownloads](#maxconcurrentdownloads)       | `number`  | Required | cannot be null | [Youtube Sync node configuration](definition-properties-yt-synch-syncronization-related-settings-properties-limits-properties-maxconcurrentdownloads.md "https://joystream.org/schemas/youtube-synch/config#/properties/sync/properties/limits/properties/maxConcurrentDownloads")                                                |
+| [createVideoTxBatchSize](#createvideotxbatchsize)       | `number`  | Required | cannot be null | [Youtube Sync node configuration](definition-properties-yt-synch-syncronization-related-settings-properties-limits-properties-createvideotxbatchsize.md "https://joystream.org/schemas/youtube-synch/config#/properties/sync/properties/limits/properties/createVideoTxBatchSize")                                                |
+| [maxConcurrentUploads](#maxconcurrentuploads)           | `number`  | Required | cannot be null | [Youtube Sync node configuration](definition-properties-yt-synch-syncronization-related-settings-properties-limits-properties-maxconcurrentuploads.md "https://joystream.org/schemas/youtube-synch/config#/properties/sync/properties/limits/properties/maxConcurrentUploads")                                                    |
+| [pendingDownloadTimeoutSec](#pendingdownloadtimeoutsec) | `integer` | Required | cannot be null | [Youtube Sync node configuration](definition-properties-yt-synch-syncronization-related-settings-properties-limits-properties-pendingdownloadtimeoutsec.md "https://joystream.org/schemas/youtube-synch/config#/properties/sync/properties/limits/properties/pendingDownloadTimeoutSec")                                          |
+| [storage](#storage)                                     | `string`  | Required | cannot be null | [Youtube Sync node configuration](definition-properties-yt-synch-syncronization-related-settings-properties-limits-properties-storage.md "https://joystream.org/schemas/youtube-synch/config#/properties/sync/properties/limits/properties/storage")                                                                              |
 
 ## dailyApiQuota
 
@@ -19,13 +19,13 @@ Specifies daily Youtube API quota rationing scheme for Youtube Partner Program
 
 `dailyApiQuota`
 
-- is required
+*   is required
 
-- Type: `object` ([Specifies daily Youtube API quota rationing scheme for Youtube Partner Program](definition-properties-yt-synch-syncronization-related-settings-properties-limits-properties-specifies-daily-youtube-api-quota-rationing-scheme-for-youtube-partner-program.md))
+*   Type: `object` ([Specifies daily Youtube API quota rationing scheme for Youtube Partner Program](definition-properties-yt-synch-syncronization-related-settings-properties-limits-properties-specifies-daily-youtube-api-quota-rationing-scheme-for-youtube-partner-program.md))
 
-- cannot be null
+*   cannot be null
 
-- defined in: [Youtube Sync node configuration](definition-properties-yt-synch-syncronization-related-settings-properties-limits-properties-specifies-daily-youtube-api-quota-rationing-scheme-for-youtube-partner-program.md 'https://joystream.org/schemas/youtube-synch/config#/properties/sync/properties/limits/properties/dailyApiQuota')
+*   defined in: [Youtube Sync node configuration](definition-properties-yt-synch-syncronization-related-settings-properties-limits-properties-specifies-daily-youtube-api-quota-rationing-scheme-for-youtube-partner-program.md "https://joystream.org/schemas/youtube-synch/config#/properties/sync/properties/limits/properties/dailyApiQuota")
 
 ### dailyApiQuota Type
 
@@ -37,13 +37,13 @@ Max no. of videos that should be concurrently downloaded from Youtube to be prep
 
 `maxConcurrentDownloads`
 
-- is required
+*   is required
 
-- Type: `number`
+*   Type: `number`
 
-- cannot be null
+*   cannot be null
 
-- defined in: [Youtube Sync node configuration](definition-properties-yt-synch-syncronization-related-settings-properties-limits-properties-maxconcurrentdownloads.md 'https://joystream.org/schemas/youtube-synch/config#/properties/sync/properties/limits/properties/maxConcurrentDownloads')
+*   defined in: [Youtube Sync node configuration](definition-properties-yt-synch-syncronization-related-settings-properties-limits-properties-maxconcurrentdownloads.md "https://joystream.org/schemas/youtube-synch/config#/properties/sync/properties/limits/properties/maxConcurrentDownloads")
 
 ### maxConcurrentDownloads Type
 
@@ -63,13 +63,13 @@ No. of videos that should be created in a batched 'create_video' tx
 
 `createVideoTxBatchSize`
 
-- is required
+*   is required
 
-- Type: `number`
+*   Type: `number`
 
-- cannot be null
+*   cannot be null
 
-- defined in: [Youtube Sync node configuration](definition-properties-yt-synch-syncronization-related-settings-properties-limits-properties-createvideotxbatchsize.md 'https://joystream.org/schemas/youtube-synch/config#/properties/sync/properties/limits/properties/createVideoTxBatchSize')
+*   defined in: [Youtube Sync node configuration](definition-properties-yt-synch-syncronization-related-settings-properties-limits-properties-createvideotxbatchsize.md "https://joystream.org/schemas/youtube-synch/config#/properties/sync/properties/limits/properties/createVideoTxBatchSize")
 
 ### createVideoTxBatchSize Type
 
@@ -89,13 +89,13 @@ Max no. of videos that should be concurrently uploaded to Joystream's storage no
 
 `maxConcurrentUploads`
 
-- is required
+*   is required
 
-- Type: `number`
+*   Type: `number`
 
-- cannot be null
+*   cannot be null
 
-- defined in: [Youtube Sync node configuration](definition-properties-yt-synch-syncronization-related-settings-properties-limits-properties-maxconcurrentuploads.md 'https://joystream.org/schemas/youtube-synch/config#/properties/sync/properties/limits/properties/maxConcurrentUploads')
+*   defined in: [Youtube Sync node configuration](definition-properties-yt-synch-syncronization-related-settings-properties-limits-properties-maxconcurrentuploads.md "https://joystream.org/schemas/youtube-synch/config#/properties/sync/properties/limits/properties/maxConcurrentUploads")
 
 ### maxConcurrentUploads Type
 
@@ -115,13 +115,13 @@ Timeout for pending youtube video downloads in seconds
 
 `pendingDownloadTimeoutSec`
 
-- is required
+*   is required
 
-- Type: `integer`
+*   Type: `integer`
 
-- cannot be null
+*   cannot be null
 
-- defined in: [Youtube Sync node configuration](definition-properties-yt-synch-syncronization-related-settings-properties-limits-properties-pendingdownloadtimeoutsec.md 'https://joystream.org/schemas/youtube-synch/config#/properties/sync/properties/limits/properties/pendingDownloadTimeoutSec')
+*   defined in: [Youtube Sync node configuration](definition-properties-yt-synch-syncronization-related-settings-properties-limits-properties-pendingdownloadtimeoutsec.md "https://joystream.org/schemas/youtube-synch/config#/properties/sync/properties/limits/properties/pendingDownloadTimeoutSec")
 
 ### pendingDownloadTimeoutSec Type
 
@@ -137,13 +137,13 @@ Maximum total size of all downloaded assets stored in `downloadsDir`
 
 `storage`
 
-- is required
+*   is required
 
-- Type: `string`
+*   Type: `string`
 
-- cannot be null
+*   cannot be null
 
-- defined in: [Youtube Sync node configuration](definition-properties-yt-synch-syncronization-related-settings-properties-limits-properties-storage.md 'https://joystream.org/schemas/youtube-synch/config#/properties/sync/properties/limits/properties/storage')
+*   defined in: [Youtube Sync node configuration](definition-properties-yt-synch-syncronization-related-settings-properties-limits-properties-storage.md "https://joystream.org/schemas/youtube-synch/config#/properties/sync/properties/limits/properties/storage")
 
 ### storage Type
 
@@ -151,10 +151,10 @@ Maximum total size of all downloaded assets stored in `downloadsDir`
 
 ### storage Constraints
 
-**pattern**: the string must match the following regular expression:
+**pattern**: the string must match the following regular expression: 
 
 ```regexp
 ^[0-9]+(B|K|M|G|T)$
 ```
 
-[try pattern](<https://regexr.com/?expression=%5E%5B0-9%5D%2B(B%7CK%7CM%7CG%7CT)%24> 'try regular expression with regexr.com')
+[try pattern](https://regexr.com/?expression=%5E%5B0-9%5D%2B\(B%7CK%7CM%7CG%7CT\)%24 "try regular expression with regexr.com")

--- a/docs/config/definition.md
+++ b/docs/config/definition.md
@@ -4,16 +4,17 @@
 
 # Youtube Sync node configuration Properties
 
-| Property                                                        | Type     | Required | Nullable       | Defined by                                                                                                                                                                                   |
-| :-------------------------------------------------------------- | :------- | :------- | :------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [joystream](#joystream)                                         | `object` | Required | cannot be null | [Youtube Sync node configuration](definition-properties-joystream.md "https://joystream.org/schemas/youtube-synch/config#/properties/joystream")                                             |
-| [endpoints](#endpoints)                                         | `object` | Required | cannot be null | [Youtube Sync node configuration](definition-properties-endpoints.md "https://joystream.org/schemas/youtube-synch/config#/properties/endpoints")                                             |
-| [logs](#logs)                                                   | `object` | Optional | cannot be null | [Youtube Sync node configuration](definition-properties-logs.md "https://joystream.org/schemas/youtube-synch/config#/properties/logs")                                                       |
-| [youtube](#youtube)                                             | `object` | Required | cannot be null | [Youtube Sync node configuration](definition-properties-youtube-oauth2-client-configuration.md "https://joystream.org/schemas/youtube-synch/config#/properties/youtube")                     |
-| [aws](#aws)                                                     | `object` | Optional | cannot be null | [Youtube Sync node configuration](definition-properties-aws-configurations-needed-to-connect-with-dynamodb-instance.md "https://joystream.org/schemas/youtube-synch/config#/properties/aws") |
-| [creatorOnboardingRequirements](#creatoronboardingrequirements) | `object` | Required | cannot be null | [Youtube Sync node configuration](definition-properties-creatoronboardingrequirements.md "https://joystream.org/schemas/youtube-synch/config#/properties/creatorOnboardingRequirements")     |
-| [httpApi](#httpapi)                                             | `object` | Required | cannot be null | [Youtube Sync node configuration](definition-properties-public-api-configuration.md "https://joystream.org/schemas/youtube-synch/config#/properties/httpApi")                                |
-| [sync](#sync)                                                   | `object` | Required | cannot be null | [Youtube Sync node configuration](definition-properties-yt-synch-syncronization-related-settings.md "https://joystream.org/schemas/youtube-synch/config#/properties/sync")                   |
+| Property                                                        | Type     | Required | Nullable       | Defined by                                                                                                                                                                                                           |
+| :-------------------------------------------------------------- | :------- | :------- | :------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [joystream](#joystream)                                         | `object` | Required | cannot be null | [Youtube Sync node configuration](definition-properties-joystream.md "https://joystream.org/schemas/youtube-synch/config#/properties/joystream")                                                                     |
+| [endpoints](#endpoints)                                         | `object` | Required | cannot be null | [Youtube Sync node configuration](definition-properties-endpoints.md "https://joystream.org/schemas/youtube-synch/config#/properties/endpoints")                                                                     |
+| [logs](#logs)                                                   | `object` | Optional | cannot be null | [Youtube Sync node configuration](definition-properties-logs.md "https://joystream.org/schemas/youtube-synch/config#/properties/logs")                                                                               |
+| [youtube](#youtube)                                             | `object` | Required | cannot be null | [Youtube Sync node configuration](definition-properties-youtube-oauth2-client-configuration.md "https://joystream.org/schemas/youtube-synch/config#/properties/youtube")                                             |
+| [aws](#aws)                                                     | `object` | Optional | cannot be null | [Youtube Sync node configuration](definition-properties-aws-configurations-needed-to-connect-with-dynamodb-instance.md "https://joystream.org/schemas/youtube-synch/config#/properties/aws")                         |
+| [proxy](#proxy)                                                 | `object` | Optional | cannot be null | [Youtube Sync node configuration](definition-properties-socks5-proxy-client-configuration-used-by-yt-dlp-to-bypass-ip-blockage-by-youtube.md "https://joystream.org/schemas/youtube-synch/config#/properties/proxy") |
+| [creatorOnboardingRequirements](#creatoronboardingrequirements) | `object` | Required | cannot be null | [Youtube Sync node configuration](definition-properties-creatoronboardingrequirements.md "https://joystream.org/schemas/youtube-synch/config#/properties/creatorOnboardingRequirements")                             |
+| [httpApi](#httpapi)                                             | `object` | Required | cannot be null | [Youtube Sync node configuration](definition-properties-public-api-configuration.md "https://joystream.org/schemas/youtube-synch/config#/properties/httpApi")                                                        |
+| [sync](#sync)                                                   | `object` | Required | cannot be null | [Youtube Sync node configuration](definition-properties-yt-synch-syncronization-related-settings.md "https://joystream.org/schemas/youtube-synch/config#/properties/sync")                                           |
 
 ## joystream
 
@@ -104,6 +105,24 @@ AWS configurations needed to connect with DynamoDB instance
 ### aws Type
 
 `object` ([AWS configurations needed to connect with DynamoDB instance](definition-properties-aws-configurations-needed-to-connect-with-dynamodb-instance.md))
+
+## proxy
+
+Socks5 proxy client configuration used by yt-dlp to bypass IP blockage by Youtube
+
+`proxy`
+
+*   is optional
+
+*   Type: `object` ([Socks5 proxy client configuration used by yt-dlp to bypass IP blockage by Youtube](definition-properties-socks5-proxy-client-configuration-used-by-yt-dlp-to-bypass-ip-blockage-by-youtube.md))
+
+*   cannot be null
+
+*   defined in: [Youtube Sync node configuration](definition-properties-socks5-proxy-client-configuration-used-by-yt-dlp-to-bypass-ip-blockage-by-youtube.md "https://joystream.org/schemas/youtube-synch/config#/properties/proxy")
+
+### proxy Type
+
+`object` ([Socks5 proxy client configuration used by yt-dlp to bypass IP blockage by Youtube](definition-properties-socks5-proxy-client-configuration-used-by-yt-dlp-to-bypass-ip-blockage-by-youtube.md))
 
 ## creatorOnboardingRequirements
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "youtube-sync",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "license": "MIT",
   "scripts": {
     "postpack": "rm -f oclif.manifest.json",

--- a/socks5-proxy/SETUP.md
+++ b/socks5-proxy/SETUP.md
@@ -12,9 +12,11 @@ This setup is designed to automate the restarting of an Amazon EC2 instance and 
 
 3. **Docker and Docker Compose**: Used to manage the Chisel client container.
 
-4. **Bash Script (`restart-ec2-proxy-instance.sh`)**: A script to automate the stopping and starting of the EC2 instance and updating the Docker Compose configuration with the new IP address.
+4. **Bash Script (`start-proxy-client.sh`)**: A script to start to Chisel proxy client on the client machine.
 
-5. **Docker Compose File (`docker-compose.chisel.yml`)**: Configuration file for Docker Compose to set up the Chisel client.
+5. **Bash Script (`restart-ec2-proxy-instance.sh`)**: A script to automate the stopping and starting of the EC2 instance where Chisel server is running and updating the Docker Compose configuration with the new IP address.
+
+6. **Docker Compose File (`docker-compose.chisel.yml`)**: Configuration file for Docker Compose to set up the Chisel client.
 
 ## System Requirements
 
@@ -31,7 +33,7 @@ This setup is designed to automate the restarting of an Amazon EC2 instance and 
 
 ### Bash Script Configuration
 
-1. Create a `.env` file in the same directory as the `restart-ec2-proxy-instance.sh` script with your EC2 instance ID and the Chisel server's fingerprint. For example:
+1. Create a `.env` file in the same directory as the `restart-ec2-proxy-instance.sh` & `start-proxy-client.sh` script with your EC2 instance ID and the Chisel server's fingerprint. For example:
 
    ```
    INSTANCE_ID="EC2_INSTANCE_ID"
@@ -39,9 +41,10 @@ This setup is designed to automate the restarting of an Amazon EC2 instance and 
 
    ```
 
-2. Make the script executable:
+2. Make the scripts executable:
    ```bash
    chmod +x restart-ec2-proxy-instance.sh
+   chmod +x start-proxy-client.sh
    ```
 
 ### Starting Chisel Server on EC2 Instance
@@ -61,3 +64,11 @@ docker logs chisel-server
 ```
 
 Copy the fingerprint and add it to the `.env` file for `CHISEL_SERVER_FINGERPRINT` env var.
+
+### Starting Chisel Client on Client Machine
+
+To start the Chisel client on the client machine, execute the following command:
+
+```bash
+./start-proxy-client.sh
+```

--- a/socks5-proxy/SETUP.md
+++ b/socks5-proxy/SETUP.md
@@ -1,0 +1,63 @@
+# SETUP.md
+
+## Overview
+
+This setup is designed to automate the restarting of an Amazon EC2 instance and update a Docker Compose deployment with the new IP address of the EC2 instance. The Docker Compose setup runs a Chisel client which connects to a Chisel server hosted on the EC2 instance.
+
+## Components
+
+1. **Amazon EC2 Instance**: A server that will be stopped and started by the script running on the client machine, resulting in a new public IP address assignment of EC2 proxy server instance.
+
+2. **Chisel**: A fast TCP tunnel over HTTP. In this setup, a Chisel client is run in a Docker container, which connects to a Chisel server running on the EC2 instance.
+
+3. **Docker and Docker Compose**: Used to manage the Chisel client container.
+
+4. **Bash Script (`restart-ec2-proxy-instance.sh`)**: A script to automate the stopping and starting of the EC2 instance and updating the Docker Compose configuration with the new IP address.
+
+5. **Docker Compose File (`docker-compose.chisel.yml`)**: Configuration file for Docker Compose to set up the Chisel client.
+
+## System Requirements
+
+- **AWS CLI**: Command line tool for interacting with AWS services.
+- **Docker**: Platform for developing, shipping, and running applications.
+- **Docker Compose**: Tool for defining and running multi-container Docker applications.
+
+## Installation & Configuration
+
+### AWS CLI
+
+1. **Install AWS CLI**: Follow the instructions on the [AWS CLI installation page](https://aws.amazon.com/cli/).
+2. **Configure AWS CLI**: Run `aws configure` and enter your AWS credentials (Access Key ID, Secret Access Key) and default region.
+
+### Bash Script Configuration
+
+1. Create a `.env` file in the same directory as the `restart-ec2-proxy-instance.sh` script with your EC2 instance ID and the Chisel server's fingerprint. For example:
+
+   ```
+   INSTANCE_ID="EC2_INSTANCE_ID"
+   CHISEL_SERVER_FINGERPRINT="CHISEL_SERVER_FINGERPRINT" (see below for instructions on how to retrieve the fingerprint)
+
+   ```
+
+2. Make the script executable:
+   ```bash
+   chmod +x restart-ec2-proxy-instance.sh
+   ```
+
+### Starting Chisel Server on EC2 Instance
+
+To run the Chisel server on the EC2 instance, execute the following Docker command. This command starts a Chisel server Docker container that listens on port 8080.
+
+```bash
+docker run -d --name chisel-server -p 8080:8080 --restart=always jpillora/chisel server --key 'random-key' --port 8080 --socks5
+```
+
+Where `--key` is a string to seed the generation of a ECDSA public and private key pair. All communications will be secured using this key pair.
+
+After starting the Chisel server, you can retrieve the server's fingerprint by inspecting the docker-compose logs:
+
+```bash
+docker logs chisel-server
+```
+
+Copy the fingerprint and add it to the `.env` file for `CHISEL_SERVER_FINGERPRINT` env var.

--- a/socks5-proxy/docker-compose.chisel.yml
+++ b/socks5-proxy/docker-compose.chisel.yml
@@ -1,0 +1,14 @@
+version: '3.4'
+
+services:
+  chisel-client:
+    image: jpillora/chisel
+    container_name: chisel-client
+    command: client --fingerprint ${CHISEL_SERVER_FINGERPRINT} ${IP_ADDRESS}:8080 0.0.0.0:1080:socks
+    restart: always
+    networks:
+      - youtube-synch
+
+networks:
+  youtube-synch:
+    external: true

--- a/socks5-proxy/restart-ec2-proxy-instance.sh
+++ b/socks5-proxy/restart-ec2-proxy-instance.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -e
+
+# This script is used to stop and start the EC2 machine, which automatically
+# assigns a new IP address to EC@ machine and hence to socks5 proxy too.
+
+set -a
+if [ -f .env ]; then
+    . .env
+fi
+set +a
+
+# Set your EC2 Instance ID and region
+INSTANCE_ID=$INSTANCE_ID
+
+# Fingerprint (Key) needed to connect to the Chisel Sever by Chisel Client running on the client machine
+
+# Stopping an instance
+echo -e "Stopping EC2 proxy server instance... \n"
+aws ec2 stop-instances --instance-ids $INSTANCE_ID
+aws ec2 wait instance-stopped --instance-ids $INSTANCE_ID
+
+# Starting an instance
+echo -e "Starting EC2 proxy server instance... \n"
+aws ec2 start-instances --instance-ids $INSTANCE_ID
+aws ec2 wait instance-running --instance-ids $INSTANCE_ID
+
+# Fetch the current public IP of the EC2 instance
+echo -e "Fetching new assigned IP address of proxy server instance... \n"
+IP_ADDRESS=$(aws ec2 describe-instances --instance-ids $INSTANCE_ID --query "Reservations[*].Instances[*].PublicIpAddress" --output text)
+
+# Check if IP address is fetched
+if [ -z "$IP_ADDRESS" ]; then
+    echo "Failed to fetch IP address"
+    exit 1
+fi
+
+sleep 30
+
+# Export new IP address of ec2 instance to be used by chisel proxy client
+export IP_ADDRESS=$IP_ADDRESS
+
+# Restart the docker-compose chisel client service
+echo -e "Reatarting Chisel Client... \n"
+docker rm -f chisel-client
+docker-compose -f ./docker-compose.chisel.yml up -d chisel-client

--- a/socks5-proxy/start-proxy-client.sh
+++ b/socks5-proxy/start-proxy-client.sh
@@ -1,0 +1,30 @@
+set -e
+
+SCRIPT_PATH="$(dirname "${BASH_SOURCE[0]}")"
+cd $SCRIPT_PATH
+
+set -a
+if [ -f .env ]; then
+    . .env
+fi
+set +a
+
+# Fetch the current public IP of the EC2 instance
+echo -e "Fetching new assigned IP address of proxy server instance... \n"
+IP_ADDRESS=$(aws ec2 describe-instances --instance-ids $INSTANCE_ID --query "Reservations[*].Instances[*].PublicIpAddress" --output text)
+
+# Check if IP address is fetched
+if [ -z "$IP_ADDRESS" ]; then
+    echo "Failed to fetch IP address"
+    exit 1
+fi
+
+# Export new IP address of ec2 instance to be used by chisel proxy client
+export IP_ADDRESS=$IP_ADDRESS
+
+# Restart the docker-compose chisel client service
+echo -e "Restarting Chisel Client... \n"
+docker rm -f chisel-client >/dev/null 2>&1
+
+export COMPOSE_HTTP_TIMEOUT=120 # Increase to 120 seconds
+docker-compose -f ./docker-compose.chisel.yml up -d chisel-client

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -91,7 +91,6 @@ export class Service {
         intervals: { youtubePolling, contentProcessing },
       } = this.config.sync
       this.logger.verbose('Starting the Youtube-Synch service', { config: this.hideSecrets(this.config) })
-      // Null-assertion is safe here since intervals won't be not null due to Ajv schema validation
       await this.youtubePollingService.start(youtubePolling)
       await this.contentProcessingService.start(contentProcessing)
     }

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -44,7 +44,7 @@ export class Service {
         this.joystreamClient
       )
       this.contentProcessingService = new ContentProcessingService(
-        { ...config.sync, ...config.endpoints },
+        { ...config.sync, ...config.endpoints, ...config.proxy },
         this.logging,
         this.dynamodbService,
         this.youtubeApi,

--- a/src/repository/channel.ts
+++ b/src/repository/channel.ts
@@ -70,6 +70,19 @@ function createChannelModel(tablePrefix: ResourcePrefix) {
       // Youtube channel creation date
       publishedAt: String,
 
+      // Timestamp when the channel verification was processed, either to Verified or Suspended
+      processedAt: {
+        type: {
+          value: Date,
+          settings: {
+            storage: 'iso',
+          },
+        },
+        get: (value: any) => {
+          return new Date(value)
+        },
+      },
+
       // Timestamp of the last action performed by channel owner (using its owner controller keys)
       lastActedAt: {
         type: {
@@ -212,10 +225,9 @@ export class ChannelsRepository implements IRepository<YtChannel> {
   }
 
   async upsertAll(channels: YtChannel[]): Promise<YtChannel[]> {
-    return this.withLock(async () => {
-      const results = await Promise.all(channels.map(async (channel) => await this.save(channel)))
-      return results
-    })
+    // Intentionally not locking this method because save already locks each element
+    const results = await Promise.all(channels.map(async (channel) => await this.save(channel)))
+    return results
   }
 
   async scan(init: ConditionInitializer, f: (q: Scan<AnyItem>) => Scan<AnyItem>): Promise<YtChannel[]> {

--- a/src/repository/video.ts
+++ b/src/repository/video.ts
@@ -5,7 +5,7 @@ import { AnyItem } from 'dynamoose/dist/Item'
 import { Query, QueryResponse, Scan, ScanResponse } from 'dynamoose/dist/ItemRetriever'
 import { omit } from 'ramda'
 import { DYNAMO_MODEL_OPTIONS, IRepository, mapTo } from '.'
-import { ResourcePrefix, VideoState, YtChannel, YtVideo, videoStates } from '../types/youtube'
+import { ResourcePrefix, VideoState, YtVideo, videoStates } from '../types/youtube'
 
 function videoRepository(tablePrefix: ResourcePrefix) {
   const videoSchema = new dynamoose.Schema(
@@ -270,16 +270,6 @@ export class VideosService {
 
   async getVideosPendingOnchainCreation(): Promise<YtVideo[]> {
     return [...(await this.getVideosInState('VideoCreationFailed')), ...(await this.getVideosInState('New'))]
-  }
-
-  async getHistoricalUnsyncedVideosOfChannel(channel: YtChannel): Promise<YtVideo[]> {
-    const videos = await this.videosRepository.query({ channelId: channel.id }, (q) =>
-      q.using('channelId-publishedAt-index')
-    )
-
-    return videos.filter(
-      (v) => new Date(v.publishedAt) < channel.createdAt && (v.state === 'New' || v.state === 'VideoCreationFailed')
-    )
   }
 
   /**

--- a/src/schemas/config.ts
+++ b/src/schemas/config.ts
@@ -200,7 +200,6 @@ export const configSchema: JSONSchema7 = objectSchema({
     aws: objectSchema({
       title: 'AWS configurations needed to connect with DynamoDB instance',
       description: 'AWS configurations needed to connect with DynamoDB instance',
-
       properties: {
         endpoint: {
           type: 'string',
@@ -224,6 +223,33 @@ export const configSchema: JSONSchema7 = objectSchema({
       },
       required: [],
     }),
+    proxy: objectSchema({
+      title: 'Socks5 proxy client configuration used by yt-dlp to bypass IP blockage by Youtube',
+      description: 'Socks5 proxy client configuration used by yt-dlp to bypass IP blockage by Youtube',
+      properties: {
+        url: {
+          description: 'Proxy Client URL e.g. socks://localhost:1080, socks://user:password@localhost:1080',
+          type: 'string',
+        },
+        chiselProxy: objectSchema({
+          description:
+            'Configuration option to manage Chisel Client & Server. Before enabling this option please refer to setup guide in `socks5-proxy/SETUP.md`',
+          properties: {
+            ec2AutoRotateIp: {
+              description:
+                'Boolean option to enable auto rotation of ec2 instance IP where chisel server is running by restating it',
+              type: 'boolean',
+            },
+          },
+          required: [],
+        }),
+      },
+      dependencies: {
+        chiselProxy: ['url'],
+      },
+      required: [],
+    }),
+
     creatorOnboardingRequirements: objectSchema({
       description: 'Specifies creator onboarding (signup) requirements for Youtube Partner Program',
       properties: {

--- a/src/services/httpApi/dtos.ts
+++ b/src/services/httpApi/dtos.ts
@@ -85,6 +85,11 @@ export class ChannelInductionRequirementsDto {
         template: 'YouTube channel has at least {}.',
         variables: [pluralizeNoun(requirements.minimumVideosCount, 'video')],
       },
+      {
+        errorCode: ExitCodes.YoutubeApi.CHANNEL_CRITERIA_UNMET_CREATION_DATE,
+        template: 'YouTube channel needs to be older than {}.',
+        variables: [pluralizeNoun(Math.round(requirements.minimumChannelAgeHours * 0.001), 'month')],
+      },
     ]
   }
 }

--- a/src/services/logging/LoggingService.ts
+++ b/src/services/logging/LoggingService.ts
@@ -70,6 +70,14 @@ export class LoggingService {
   private constructor(options: LoggerOptions, esTransport?: ElasticsearchTransport) {
     this.esTransport = esTransport
     this.rootLogger = winston.createLogger(options)
+
+    // Compulsory error handling
+    this.rootLogger.on('error', (error) => {
+      console.error('Error in logger caught:', error)
+    })
+    this.esTransport?.on('error', (error) => {
+      console.error('Error in logger caught:', error)
+    })
   }
 
   public static withAppConfig(logs: ReadonlyConfig['logs']): LoggingService {

--- a/src/services/syncProcessing/ContentDownloadService.ts
+++ b/src/services/syncProcessing/ContentDownloadService.ts
@@ -70,7 +70,7 @@ export class ContentDownloadService {
         return videoId
       })
     this.logger.verbose(`Resolved already downloaded video assets in local storage`, {
-      resolvedDownloads,
+      resolvedDownloads: resolvedDownloads.length,
       usedSpace: SyncUtils.usedSpace,
     })
   }

--- a/src/services/syncProcessing/PriorityQueue.ts
+++ b/src/services/syncProcessing/PriorityQueue.ts
@@ -198,8 +198,19 @@ export class PriorityJobQueue<
 
           for (const job of unprocessedJobs) {
             let sudoPriority = SyncUtils.DEFAULT_SUDO_PRIORITY
+
+            // Prioritize syncing new videos over old ones
             if (new Date(job.data.publishedAt) > channel.createdAt && job.data.duration > 300) {
-              sudoPriority += 50
+              sudoPriority += 20
+            }
+
+            // Prioritize syncing videos of the non-Bronze channels
+            if (
+              channel.yppStatus === 'Verified::Diamond' ||
+              channel.yppStatus === 'Verified::Gold' ||
+              channel.yppStatus === 'Verified::Silver'
+            ) {
+              sudoPriority += 20
             }
 
             const priority = SyncUtils.calculateJobPriority(

--- a/src/services/syncProcessing/YoutubePollingService.ts
+++ b/src/services/syncProcessing/YoutubePollingService.ts
@@ -1,9 +1,7 @@
-import { GaxiosError } from 'gaxios/build/src/common'
 import _ from 'lodash'
 import sleep from 'sleep-promise'
 import { Logger } from 'winston'
 import { IDynamodbService } from '../../repository'
-import { ExitCodes, YoutubeApiError } from '../../types/errors'
 import { YtChannel, YtDlpFlatPlaylistOutput, verifiedVariants } from '../../types/youtube'
 import { LoggingService } from '../logging'
 import { JoystreamClient } from '../runtime/client'
@@ -68,8 +66,9 @@ export class YoutubePollingService {
         // Ingest videos of channels in a batch of 50 to limit IO/CPU resource consumption
         const channelsBatch = _.chunk(channels, 50)
         // Process each batch
-        for (let i = 0; i < channelsBatch.length; i++) {
-          await Promise.all(channelsBatch[i].map((channel) => this.performVideosIngestion(channel)))
+
+        for (const channels of channelsBatch) {
+          await Promise.all(channels.map((channel) => this.performVideosIngestion(channel)))
         }
       } catch (err) {
         this.logger.error(`Critical Polling error`, { err })
@@ -100,87 +99,62 @@ export class YoutubePollingService {
       )
 
     // updated channel objects with uptodate info
-    const channelsToBeIngested = await channelsWithSyncEnabled()
-    const updatedChannels = (
-      await Promise.all(
-        channelsToBeIngested.map(async (ch) => {
-          try {
-            const uptodateChannel = await this.youtubeApi.getChannel({
-              id: ch.userId,
-              accessToken: ch.userAccessToken,
-              refreshToken: ch.userRefreshToken,
-            })
+    const channelsToBeIngestedChunks = _.chunk(await channelsWithSyncEnabled(), 100)
 
-            // ensure that Ypp collaborator member is still set as channel's collaborator
-            const isCollaboratorSet = await this.joystreamClient.doesChannelHaveCollaborator(ch.joystreamChannelId)
-            if (!isCollaboratorSet) {
-              this.logger.warn(
-                `Joystream Channel ${ch.joystreamChannelId} has either not set or revoked Ypp collaborator member ` +
-                  `as channel's collaborator. Corresponding Youtube Channel '${ch.id}' is being opted out from Ypp program.`
-              )
-              return {
-                ...ch,
-                yppStatus: 'OptedOut',
-                shouldBeIngested: false,
-                lastActedAt: new Date(),
-              }
-            }
+    for (const channelsToBeIngested of channelsToBeIngestedChunks) {
+      const updatedChannels = (
+        await Promise.all(
+          channelsToBeIngested.map(async (ch) => {
+            try {
+              // ensure that channel exists on Youtube
+              await this.youtubeApi.ytdlpClient.ensureChannelExists(ch.id)
 
-            // Update the current channel record if it changed
-            if (!_.isEqual(ch.statistics, uptodateChannel.statistics)) {
-              return { ...ch, statistics: uptodateChannel.statistics }
+              // ensure that Ypp collaborator member is still set as channel's collaborator
+              const isCollaboratorSet = await this.joystreamClient.doesChannelHaveCollaborator(ch.joystreamChannelId)
+              if (!isCollaboratorSet) {
+                this.logger.warn(
+                  `Joystream Channel ${ch.joystreamChannelId} has either not set or revoked Ypp collaborator member ` +
+                    `as channel's collaborator. Corresponding Youtube Channel '${ch.id}' is being opted out from Ypp program.`
+                )
+                return {
+                  ...ch,
+                  yppStatus: 'OptedOut',
+                  shouldBeIngested: false,
+                  lastActedAt: new Date(),
+                }
+              }
+            } catch (err: unknown) {
+              if (err instanceof Error && err.message.includes('This account has been terminated')) {
+                this.logger.warn(
+                  `Opting out '${ch.id}' from YPP program as their Youtube channel has been terminated by the Youtube.`
+                )
+                return {
+                  ...ch,
+                  yppStatus: 'OptedOut',
+                  shouldBeIngested: false,
+                  lastActedAt: new Date(),
+                }
+              } else if (err instanceof Error && err.message.includes('The playlist does not exist')) {
+                this.logger.warn(`Opting out '${ch.id}' from YPP program as Channel does not exist on Youtube.`)
+                return {
+                  ...ch,
+                  yppStatus: 'OptedOut',
+                  shouldBeIngested: false,
+                  lastActedAt: new Date(),
+                }
+              }
+              this.logger.error('Failed to fetch updated channel info', { err, channelId: ch.joystreamChannelId })
             }
-          } catch (err: unknown) {
-            // if app permission is revoked by user from Google account then set `shouldBeIngested` to false & OptOut channel from
-            // Ypp program,  because then trying to fetch user channel will throw error with code 400 and 'invalid_grant' message
-            if (err instanceof GaxiosError && err.code === '400' && err.response?.data?.error === 'invalid_grant') {
-              this.logger.warn(
-                `Opting out '${ch.id}' from YPP program as their owner has revoked the permissions from Google settings`
-              )
-              return {
-                ...ch,
-                yppStatus: 'OptedOut',
-                shouldBeIngested: false,
-                lastActedAt: new Date(),
-              }
-              // ! Although type of `err.code` is string, the api api response returns it as number.
-            } else if (
-              err instanceof GaxiosError &&
-              err.code === (403 as any) &&
-              (err as GaxiosError).response?.data?.error?.errors[0]?.reason === 'authenticatedUserAccountSuspended'
-            ) {
-              this.logger.warn(
-                `Opting out '${ch.id}' from YPP program as their Youtube channel has been terminated by the Youtube.`
-              )
-              return {
-                ...ch,
-                yppStatus: 'OptedOut',
-                shouldBeIngested: false,
-                lastActedAt: new Date(),
-              }
-            } else if (err instanceof YoutubeApiError && err.code === ExitCodes.YoutubeApi.CHANNEL_NOT_FOUND) {
-              this.logger.warn(`Opting out '${ch.id}' from YPP program as Channel is not found on Youtube.`)
-              return {
-                ...ch,
-                yppStatus: 'OptedOut',
-                shouldBeIngested: false,
-                lastActedAt: new Date(),
-              }
-            } else if (
-              err instanceof YoutubeApiError &&
-              err.code === ExitCodes.YoutubeApi.YOUTUBE_QUOTA_LIMIT_EXCEEDED
-            ) {
-              this.logger.info('Youtube quota limit exceeded, skipping polling for now.')
-              return
-            }
-            this.logger.error('Failed to fetch updated channel info', { err, channelId: ch.joystreamChannelId })
-          }
-        })
-      )
-    ).filter((ch): ch is YtChannel => ch !== undefined)
+          })
+        )
+      ).filter((ch): ch is YtChannel => ch !== undefined)
 
-    // save updated  channels
-    await this.dynamodbService.repo.channels.upsertAll(updatedChannels)
+      // save updated  channels
+      await this.dynamodbService.repo.channels.upsertAll(updatedChannels)
+
+      // A delay between batches if necessary to prevent rate limits or high CPU/IO usage
+      await sleep(1000)
+    }
 
     return channelsWithSyncEnabled()
   }
@@ -209,11 +183,6 @@ export class YoutubePollingService {
       // save all new videos to DB including
       await this.dynamodbService.repo.videos.upsertAll(untrackedVideos)
     } catch (err) {
-      if (err instanceof YoutubeApiError && err.code === ExitCodes.YoutubeApi.YOUTUBE_QUOTA_LIMIT_EXCEEDED) {
-        this.logger.info('Youtube quota limit exceeded, skipping polling for now.')
-        return
-      }
-
       this.logger.error('Failed to ingest videos for channel', { err, channelId: channel.joystreamChannelId })
     }
   }

--- a/src/services/syncProcessing/index.ts
+++ b/src/services/syncProcessing/index.ts
@@ -179,12 +179,17 @@ export class ContentProcessingService {
     // to be uploaded on the storage network. Otherwise postpone the video creation.
     const spaceCondition = freeSpace > 0 || (freeSpace <= 0 && video.joystreamVideo !== undefined)
 
-    return (
+    const shouldBeProcessed =
       isSyncEnabled &&
       isCollaboratorSet &&
       (!isHistoricalVideo || (isHistoricalVideo && !sizeLimitReached)) &&
       spaceCondition
-    )
+
+    if (!shouldBeProcessed && SyncUtils.downloadedVideoFilePaths.has(video.id)) {
+      await SyncUtils.removeVideoFile(video.id)
+    }
+
+    return shouldBeProcessed
   }
 
   private async isActiveJobFlow(videoId: string): Promise<boolean> {

--- a/src/services/syncProcessing/index.ts
+++ b/src/services/syncProcessing/index.ts
@@ -140,8 +140,19 @@ export class ContentProcessingService {
         for (const video of unsyncedVideos) {
           if ((await this.ensureVideoCanBeProcessed(video, channel)) && !(await this.isActiveJobFlow(video.id))) {
             let sudoPriority = SyncUtils.DEFAULT_SUDO_PRIORITY
+
+            // Prioritize syncing new videos over old ones
             if (new Date(video.publishedAt) > channel.createdAt && video.duration > 300) {
-              sudoPriority += 50
+              sudoPriority += 20
+            }
+
+            // Prioritize syncing videos of the non-Bronze channels
+            if (
+              channel.yppStatus === 'Verified::Diamond' ||
+              channel.yppStatus === 'Verified::Gold' ||
+              channel.yppStatus === 'Verified::Silver'
+            ) {
+              sudoPriority += 20
             }
 
             const priority = SyncUtils.calculateJobPriority(

--- a/src/services/syncProcessing/index.ts
+++ b/src/services/syncProcessing/index.ts
@@ -29,7 +29,7 @@ export class ContentProcessingService {
   private contentUploadService: ContentUploadService
 
   constructor(
-    private config: Required<ReadonlyConfig['sync']> & ReadonlyConfig['endpoints'],
+    private config: Required<ReadonlyConfig['sync']> & ReadonlyConfig['endpoints'] & ReadonlyConfig['proxy'],
     logging: LoggingService,
     private dynamodbService: DynamodbService,
     youtubeApi: IYoutubeApi,

--- a/src/services/youtube/api.ts
+++ b/src/services/youtube/api.ts
@@ -370,6 +370,7 @@ class YoutubeClient implements IYoutubeApi {
       format: 'bv[height<=1080][ext=mp4]+ba[ext=m4a]/bv[height<=1080][ext=webm]+ba[ext=webm]/best[height<=1080]',
       output: `${outPath}/%(id)s.%(ext)s`,
       ffmpegLocation: ffmpegInstaller.path,
+      proxy: this.config.proxy?.url,
     })
     return response
   }

--- a/src/services/youtube/api.ts
+++ b/src/services/youtube/api.ts
@@ -21,13 +21,24 @@ import { YtChannel, YtDlpFlatPlaylistOutput, YtDlpVideoOutput, YtUser, YtVideo }
 import Schema$Video = youtube_v3.Schema$Video
 import Schema$Channel = youtube_v3.Schema$Channel
 
-export class YtDlpClient {
+export interface IOpenYTApi {
+  ensureChannelExists(channelId: string): Promise<string>
+  getVideos(channel: YtChannel, ids: string[]): Promise<YtVideo[]>
+}
+
+export class YtDlpClient implements IOpenYTApi {
   private ytdlpPath: string
   private exec
 
   constructor() {
     this.exec = promisify(exec)
     this.ytdlpPath = `${pkgDir.sync(__dirname)}/node_modules/youtube-dl-exec/bin/yt-dlp`
+  }
+
+  async ensureChannelExists(channelId: string): Promise<string> {
+    // "-I :1" is used to only fetch at most one video of the channel if it exists.
+    return (await this.exec(`${this.ytdlpPath} --print channel_id https://www.youtube.com/channel/${channelId} -I :1`))
+      .stdout
   }
 
   async getVideos(channel: YtChannel, ids: string[]): Promise<YtVideo[]> {
@@ -53,7 +64,7 @@ export class YtDlpClient {
         (video) =>
           <YtVideo>{
             id: video?.id,
-            description: video?.description,
+            description: video?.description || '',
             title: video?.title,
             channelId: video?.channel_id,
             thumbnails: {

--- a/src/types/generated/ConfigJson.d.ts
+++ b/src/types/generated/ConfigJson.d.ts
@@ -71,6 +71,7 @@ export interface YoutubeSyncNodeConfiguration {
   }
   youtube: YoutubeOauth2ClientConfiguration
   aws?: AWSConfigurationsNeededToConnectWithDynamoDBInstance
+  proxy?: Socks5ProxyClientConfigurationUsedByYtDlpToBypassIPBlockageByYoutube
   /**
    * Specifies creator onboarding (signup) requirements for Youtube Partner Program
    */
@@ -223,6 +224,24 @@ export interface AWSConfigurationsNeededToConnectWithDynamoDBInstance {
 export interface AWSCredentials {
   accessKeyId: string
   secretAccessKey: string
+}
+/**
+ * Socks5 proxy client configuration used by yt-dlp to bypass IP blockage by Youtube
+ */
+export interface Socks5ProxyClientConfigurationUsedByYtDlpToBypassIPBlockageByYoutube {
+  /**
+   * Proxy Client URL e.g. socks://localhost:1080, socks://user:password@localhost:1080
+   */
+  url?: string
+  /**
+   * Configuration option to manage Chisel Client & Server. Before enabling this option please refer to setup guide in `socks5-proxy/SETUP.md`
+   */
+  chiselProxy?: {
+    /**
+     * Boolean option to enable auto rotation of ec2 instance IP where chisel server is running by restating it
+     */
+    ec2AutoRotateIp?: boolean
+  }
 }
 /**
  * Public api configuration

--- a/src/types/youtube.ts
+++ b/src/types/youtube.ts
@@ -415,8 +415,8 @@ export type TopReferrer = {
 }
 
 export const REFERRAL_REWARD_BY_TIER: { [K in ChannelYppStatusVerified]: number } = {
-  'Bronze': 1,
-  'Silver': 12.5,
-  'Gold': 25,
-  'Diamond': 50,
+  'Bronze': 2,
+  'Silver': 25,
+  'Gold': 50,
+  'Diamond': 100,
 }

--- a/src/types/youtube.ts
+++ b/src/types/youtube.ts
@@ -96,6 +96,9 @@ export class YtChannel {
   // This field serves the purpose of nonce to avoid playback attacks
   lastActedAt: Date
 
+  // Timestamp when the channel verification was processed, either to Verified or Suspended
+  processedAt: Date
+
   // Needs a dummy partition key on GSI to be able to query by createdAt fields
   phantomKey: 'phantomData'
 

--- a/src/utils/restartEC2Instance.ts
+++ b/src/utils/restartEC2Instance.ts
@@ -1,0 +1,16 @@
+import { exec as execCallback } from 'child_process'
+import pkgDir from 'pkg-dir'
+import { promisify } from 'util'
+import { Logger } from 'winston'
+
+const exec = promisify(execCallback)
+
+export async function restartEC2Instance(logger: Logger): Promise<void> {
+  logger.error(`Encountered a 403 Forbidden error, restarting EC2 proxy server instance...`)
+  try {
+    const { stdout } = await exec(`${pkgDir.sync(__dirname)}/socks5-proxy/restart-ec2-proxy-instance.sh`)
+    logger.info(`EC2 instance restarted successfully: ${stdout}`)
+  } catch (err) {
+    logger.error(`Error occurred while restarting EC2 instance: ${(err as Error).message}`)
+  }
+}


### PR DESCRIPTION

CHANGELOG: 

- Added `chisel` proxy setup with automated IP rotation mechanism to circumvent youtube IP blockage, also integrated proxy setup with yt-synch server. See [docs](socks5-proxy/SETUP.md) for more details
- Optimizes Youtube API quota usage by using `yt-dlp` instead of youtubeApi to fetch the channel details
- Added `processedAt` in channels schema to track the timestamp when channel was processed (`Verified`/`Suspended`)
- Removed unused method from video repository
- Added YPP InductionRequirement of `CHANNEL_CRITERIA_UNMET_CREATION_DATE`
- Update video processing priority calculation to prioritize Silver+ tier channels
- **FIX**: Update referral reward values
- **FIX**: Added error handling for winston logger
- **FIX**: Remove stale downloaded videos
- **FIX**: Avoid updating some channel properties e.g. `createdAt`, `email`, `userId` on re-signup