### PR TITLE
fix: ypp signup flow by allowing more than one captch free memberships if signup workflow fails

### DIFF
--- a/src/repository/user.ts
+++ b/src/repository/user.ts
@@ -36,8 +36,8 @@ function createUserModel(tablePrefix: ResourcePrefix) {
       // User avatar url
       avatarUrl: String,
 
-      // joystream member ID for given creator.
-      joystreamMemberId: Number,
+      // Corresponding Joystream member ID/s for Youtube user created through `POST /membership` (if any)
+      joystreamMemberIds: [Number],
     },
     {
       saveUnknown: false,

--- a/src/services/httpApi/controllers/users.ts
+++ b/src/services/httpApi/controllers/users.ts
@@ -56,7 +56,7 @@ export class UsersController {
       const existingUser = await this.dynamodbService.repo.users.get(user.id)
 
       // save user & set joystreamMemberId if user already existed
-      await this.dynamodbService.users.save({ ...user, joystreamMemberId: existingUser?.joystreamMemberId })
+      await this.dynamodbService.users.save({ ...user, joystreamMemberIds: existingUser?.joystreamMemberIds || [] })
 
       // return verified user
       return {

--- a/src/services/youtube/api.ts
+++ b/src/services/youtube/api.ts
@@ -245,7 +245,7 @@ class YoutubeClient implements IYoutubeApi {
       accessToken: tokenResponse.access_token,
       refreshToken: tokenResponse.refresh_token,
       authorizationCode: code,
-      joystreamMemberId: undefined,
+      joystreamMemberIds: [],
       createdAt: new Date(),
     }
     return user

--- a/src/types/youtube.ts
+++ b/src/types/youtube.ts
@@ -183,8 +183,8 @@ export class YtUser {
   // User authorization code
   authorizationCode: string
 
-  // Corresponding Joystream member ID for Youtube user
-  joystreamMemberId: number | undefined
+  // Corresponding Joystream member ID/s for Youtube user created through `POST /membership` (if any)
+  joystreamMemberIds: number[]
 
   // Record created At timestamp
   createdAt: Date


### PR DESCRIPTION
Fixes the YPP signup flow as mentioned in #314
> We have a separate problem which has to do with a flaw in the signup flow, where there is a possibility of a session failing at certain stages, perhaps we can tackle that at the same time?

## Problem
Currently, when the signup flow fails after the captcha-free membership is created through YT-synch's `POST /membership`, during the next signup YT-synch won't allow creating the membership again (as a measure against Sybil attach where any YPP verified user can create infinitely many memberships causing faucet funds to exhaust).

## Fix
Instead of allowing the creation of only 1 membership we are allowing to creation a max of `n` memberships through YT-synch to avoid the problem of the creator not being able to sign up again when the flow fails in the first attempt.
 
After discussing with **Radek** we decided to go with this approach of fixing the flow instead of trying to recover the created membership by importing the seed (copied/saved in the previous attempt) in the external signer as that leads to a more complex UX