### PR TITLE
Polling and logging fixes

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -41,6 +41,7 @@ logs:
 youtube:
   clientId: google-client-id
   clientSecret: google-client-secret
+  apiKey: youtube-api-key
   # adcKeyFilePath: path/to/adc-key-file.json
   # maxAllowedQuotaUsageInPercentage: 95
 # proxy:

--- a/src/schemas/config.ts
+++ b/src/schemas/config.ts
@@ -177,6 +177,7 @@ export const configSchema: JSONSchema7 = objectSchema({
       properties: {
         clientId: { type: 'string', description: 'Youtube Oauth2 Client Id' },
         clientSecret: { type: 'string', description: 'Youtube Oauth2 Client Secret' },
+        apiKey: { type: 'string', description: 'Youtube API key used for the purpose retrieving public data' },
         maxAllowedQuotaUsageInPercentage: {
           description:
             `Maximum percentage of daily Youtube API quota that can be used by the Periodic polling service. ` +

--- a/src/services/syncProcessing/YoutubePollingService.ts
+++ b/src/services/syncProcessing/YoutubePollingService.ts
@@ -7,10 +7,10 @@ import { YtChannel, YtVideo, verifiedVariants } from '../../types/youtube'
 import { LoggingService } from '../logging'
 import { JoystreamClient } from '../runtime/client'
 import { IYoutubeApi } from '../youtube/api'
+import { GaxiosError } from 'googleapis-common'
 
 export class YoutubePollingService {
   private logger: Logger
-  private lastPolledChannelId: number | undefined = undefined // Track the last successfully polled channel ID
 
   public constructor(
     logging: LoggingService,
@@ -46,33 +46,27 @@ export class YoutubePollingService {
     const sleepInterval = pollingIntervalMinutes * 60 * 1000
     while (true) {
       try {
-        const channels = _.orderBy(await this.performChannelsIngestion(), ['joystreamChannelId'], ['desc'])
-
-        console.log('Total channels to be polled:', channels.length)
-        // Start polling from the last successfully polled channel ID
-        const startIndex = this.lastPolledChannelId
-          ? channels.findIndex((channel) => channel.joystreamChannelId === this.lastPolledChannelId)
-          : 0
-        const channelsToPoll = channels.slice(startIndex)
+        const channelsWithNewVideos = _.orderBy(await this.performChannelsIngestion(), ['joystreamChannelId'], ['desc'])
 
         this.logger.info(
-          `Completed Channels Ingestion. Videos of ${channelsToPoll.length} channels will be prepared for syncing in this polling cycle....`
+          `Videos of ${channelsWithNewVideos.length} channels will be prepared for syncing in this polling cycle....`
         )
 
-        // Ingest videos of channels in a batch of 50 to limit IO/CPU resource consumption
-        const channelsBatch = _.chunk(channelsToPoll, 100)
+        // Ingest videos of channels in a batch of 100 to limit IO/CPU resource consumption
+        const channelsBatches = _.chunk(channelsWithNewVideos, 100)
         // Process each batch
 
-        let a = 0
-        for (const channels of channelsBatch) {
-          a = a + channels.length
-          await Promise.all(channels.map((channel) => this.performVideosIngestion(channel)))
-          this.lastPolledChannelId = channels[channels.length - 1].joystreamChannelId // Update last polled channel ID
-          console.log('videos ingestion batch:', a)
+        let channelsProcessed = 0
+        for (const channelsBatch of channelsBatches) {
+          // TODO: Uncomment after verification
+          // await Promise.all(channelsBatch.map((channel) => this.performVideosIngestion(channel)))
+          channelsProcessed += channelsBatch.length
+          this.logger.info(`Ingested videos of ${channelsProcessed}/${channelsWithNewVideos.length} channels...`)
         }
       } catch (err) {
         this.logger.error(`Critical Polling error`, { err })
       }
+      this.logger.info(`All videos ingested.`)
       this.logger.info(`Youtube polling service paused for ${pollingIntervalMinutes} minute(s).`)
       await sleep(sleepInterval)
       this.logger.info(`Resume polling....`)
@@ -84,8 +78,7 @@ export class YoutubePollingService {
    */
   private async performChannelsIngestion(): Promise<YtChannel[]> {
     // get all channels that need to be ingested
-    const channelsWithSyncEnabled = async () =>
-      await this.dynamodbService.repo.channels.scan(
+    const channelsWithSyncEnabled = await this.dynamodbService.repo.channels.scan(
         {},
         (scan) =>
           scan
@@ -101,22 +94,22 @@ export class YoutubePollingService {
             // * ingestion as we don't have access to their access/refresh tokens
             .where('performUnauthorizedSync')
             .eq(false)
-        // .and()
-        // .where('id')
-        // .eq('UCBWgpKlykQ8yPAEmTGdsXxw')
       )
 
-    // updated channel objects with uptodate info
-    const channelsToBeIngestedChunks = _.chunk(await channelsWithSyncEnabled(), 100)
+    this.logger.info(`Found ${channelsWithSyncEnabled.length} channels with sync enabled.`)
 
-    let a = 0
-    console.log('await channelsWithSyncEnabled()', (await channelsWithSyncEnabled()).length)
-    for (const channelsToBeIngested of channelsToBeIngestedChunks) {
-      a = a + channelsToBeIngested.length
-      console.log('channels ingestion batch:', a)
+    const channelsToBeIngestedChunks = _.chunk(channelsWithSyncEnabled, 50)
+    const channelsScheduledForVideoIngestion: YtChannel[] = []
+
+    let checkedChannelsCount = 0
+    let updatedChannelsCount = 0
+    for (const channelsBatch of channelsToBeIngestedChunks) {
+      const channelsStats = await this.youtubeApi.getChannelsStats(channelsBatch.map(c => c.id))
+      const channelStatsbyId = new Map(channelsStats.map(c => [c.id, c.statistics]))
+      checkedChannelsCount += channelsBatch.length
       const updatedChannels = (
         await Promise.all(
-          channelsToBeIngested.map(async (ch) => {
+          channelsBatch.map(async (ch) => {
             try {
               // ensure that Ypp collaborator member is still set as channel's collaborator
               const isCollaboratorSet = await this.joystreamClient.doesChannelHaveCollaborator(ch.joystreamChannelId)
@@ -132,26 +125,45 @@ export class YoutubePollingService {
                   lastActedAt: new Date(),
                 }
               }
-            } catch (err: unknown) {
-              if (err instanceof Error && err.message.includes('This account has been terminated')) {
-                this.logger.warn(
-                  `Opting out '${ch.id}' from YPP program as their Youtube channel has been terminated by the Youtube.`
-                )
-                return {
-                  ...ch,
-                  yppStatus: 'OptedOut',
-                  shouldBeIngested: false,
-                  lastActedAt: new Date(),
-                }
-              } else if (err instanceof Error && err.message.includes('The playlist does not exist')) {
-                this.logger.warn(`Opting out '${ch.id}' from YPP program as Channel does not exist on Youtube.`)
-                return {
-                  ...ch,
-                  yppStatus: 'OptedOut',
-                  shouldBeIngested: false,
-                  lastActedAt: new Date(),
-                }
+              // Check channel's updated stats
+              const channelStats = channelStatsbyId.get(ch.id)
+              if (!channelStats) {
+                this.logger.warn(`Missing channel stats for channel ${ch.id}! Verifying channel status...`)
+                // TODO: Uncomment after verification
+                // try {
+                //   await this.youtubeApi.getChannel({ id: ch.userId, accessToken: ch.userAccessToken, refreshToken: ch.userRefreshToken })
+                // } catch (e) {
+                //   if (e instanceof GaxiosError && e.message.includes('YouTube account of the authenticated user is suspended')) {
+                //     this.logger.warn(
+                //       `Opting out '${ch.id}' from YPP program as their Youtube channel has been terminated by the Youtube.`
+                //     )
+                //     return {
+                //       ...ch,
+                //       yppStatus: 'OptedOut',
+                //       shouldBeIngested: false,
+                //       lastActedAt: new Date(),
+                //     }
+                //   }
+                //   this.logger.warn(`Status of channel ${ch.id} unclear. Will be skipped for this cycle...`, { err: e })
+                //   return
+                // }
+                this.logger.warn(`Status of channel ${ch.id} unclear. Will be skipped for this cycle...`)
+                return
               }
+              // Schedule for video ingestion if videoCount has changed
+              if (channelStats.videoCount !== ch.statistics.videoCount) {
+                this.logger.debug('Channel stats changed', { oldStats: ch.statistics, newStats: channelStats })
+                channelsScheduledForVideoIngestion.push(ch)
+              }
+              // Update stats in DynamoDB
+              // TODO: Uncomment after verification
+              // return {
+              //   ...ch,
+              //   statistics: {
+              //     ...channelStats
+              //   }
+              // }
+            } catch (err: unknown) {
               this.logger.error('Failed to fetch updated channel info', { err, channelId: ch.joystreamChannelId })
             }
           })
@@ -159,13 +171,21 @@ export class YoutubePollingService {
       ).filter((ch): ch is YtChannel => ch !== undefined)
 
       // save updated  channels
-      await this.dynamodbService.repo.channels.upsertAll(updatedChannels)
+      // TODO: Uncomment after verification
+      // await this.dynamodbService.repo.channels.upsertAll(updatedChannels)
+      updatedChannelsCount += updatedChannels.length
 
+      this.logger.info(`Processed ${checkedChannelsCount}/${channelsWithSyncEnabled.length} channels...`)
       // A delay between batches if necessary to prevent rate limits or high CPU/IO usage
       await sleep(100)
     }
 
-    return channelsWithSyncEnabled()
+    this.logger.info(
+      `Finished channel ingestion. ` +
+      `Updated ${updatedChannelsCount} channels.` +
+      `Found ${channelsScheduledForVideoIngestion.length} channels with new videos.`
+    )
+    return channelsScheduledForVideoIngestion
   }
 
   public async performVideosIngestion(channel: YtChannel, initialIngestion = false) {
@@ -179,7 +199,7 @@ export class YoutubePollingService {
       // get all video Ids that are not yet being tracked
       let untrackedVideos = await this.getUntrackedVideos(channel, videos)
 
-      console.log('untrackedVideos.length', videos.length, untrackedVideos.length, channel.joystreamChannelId)
+      this.logger.debug(`Found ${untrackedVideos.length} untracked videos (out of last ${videos.length}) for channel ${channel.joystreamChannelId}`)
       // save all new videos to DB including
       await this.dynamodbService.repo.videos.upsertAll(untrackedVideos)
     } catch (err) {
@@ -201,6 +221,7 @@ export class YoutubePollingService {
           ytChannelId: channel.id,
         })
 
+        // TODO: Uncomment after verification
         // await this.dynamodbService.repo.channels.save({
         //   ...channel,
         //   yppStatus: 'OptedOut',

--- a/src/services/youtube/api.ts
+++ b/src/services/youtube/api.ts
@@ -227,12 +227,17 @@ export class YoutubeClient implements IYoutubeApi {
   }
 
   private getYoutube(accessToken?: string, refreshToken?: string) {
-    const auth = this.getAuth()
-    auth.setCredentials({
-      access_token: accessToken,
-      refresh_token: refreshToken,
-    })
-    return new youtube_v3.Youtube({ auth })
+    if (accessToken || refreshToken) {
+      const auth = this.getAuth()
+      auth.setCredentials({
+        access_token: accessToken,
+        refresh_token: refreshToken,
+      })
+
+      return new youtube_v3.Youtube({ auth })
+    }
+    
+    return new youtube_v3.Youtube({ key: this.config.youtube.apiKey })
   }
 
   private async getAccessToken(

--- a/src/services/youtube/api.ts
+++ b/src/services/youtube/api.ts
@@ -4,6 +4,7 @@ import { youtube_v3 } from '@googleapis/youtube'
 import { exec } from 'child_process'
 import { GetTokenResponse } from 'google-auth-library/build/src/auth/oauth2client'
 import { GaxiosError, OAuth2Client } from 'googleapis-common'
+import { parse, toSeconds } from 'iso8601-duration'
 import _ from 'lodash'
 import moment from 'moment-timezone'
 import { FetchError } from 'node-fetch'
@@ -18,7 +19,7 @@ import { YtChannel, YtDlpFlatPlaylistOutput, YtDlpVideoOutput, YtUser, YtVideo }
 import sleep from 'sleep-promise'
 
 import Schema$Channel = youtube_v3.Schema$Channel
-import Schema$PlaylistItem = youtube_v3.Schema$PlaylistItem
+import Schema$Video = youtube_v3.Schema$Video
 import { LoggingService } from '../logging'
 import { Logger } from 'winston'
 
@@ -187,6 +188,7 @@ export interface IYoutubeApi {
   ytdlpClient: YtDlpClient
   getUserFromCode(code: string, youtubeRedirectUri: string): Promise<YtUser>
   getChannel(user: Pick<YtUser, 'id' | 'accessToken' | 'refreshToken'>): Promise<YtChannel>
+  getChannelsStats(ids: string[]): Promise<Pick<YtChannel, 'id' | 'statistics'>[]>
   getVerifiedChannel(
     user: Pick<YtUser, 'id' | 'accessToken' | 'refreshToken'>
   ): Promise<{ channel: YtChannel; errors: YoutubeApiError[] }>
@@ -224,7 +226,7 @@ export class YoutubeClient implements IYoutubeApi {
     })
   }
 
-  private getYoutube(accessToken: string, refreshToken: string) {
+  private getYoutube(accessToken?: string, refreshToken?: string) {
     const auth = this.getAuth()
     auth.setCredentials({
       access_token: accessToken,
@@ -308,6 +310,45 @@ export class YoutubeClient implements IYoutubeApi {
     }
 
     return channel
+  }
+
+  async getChannelsStats(ids: string[]): Promise<Pick<YtChannel, 'id' | 'statistics'>[]> {
+    const yt = this.getYoutube()
+
+    let nextPageToken: string = ''
+    const allChannelsStats: Pick<YtChannel, 'id' | 'statistics'>[] = []
+    do {
+      const channelsResponse = await yt.channels
+        .list({
+          id: ids,
+          part: ['id', 'statistics'],
+          maxResults: 50
+        })
+        .catch((err) => {
+          if (err instanceof FetchError && err.code === 'ENOTFOUND') {
+            throw new YoutubeApiError(ExitCodes.YoutubeApi.YOUTUBE_API_NOT_CONNECTED, err.message)
+          }
+          throw err
+        })
+      nextPageToken = channelsResponse.data.nextPageToken ?? ''
+
+      // YouTube API will return HTTP 200 even if some of the channels
+      // are missing due to being suspended or removed.
+      const channelsStats = (channelsResponse.data.items || [])
+        .flatMap(c => c.id && c.statistics ? [{ id: c.id, statistics: c.statistics }] : [])
+        .map(c => ({
+          id: c.id,
+          statistics: {
+            viewCount: parseInt(c.statistics.viewCount ?? '0'),
+            subscriberCount: parseInt(c.statistics.subscriberCount ?? '0'),
+            videoCount: parseInt(c.statistics.videoCount ?? '0'),
+            commentCount: parseInt(c.statistics.commentCount ?? '0'),
+          }
+        }))
+        allChannelsStats.push(...channelsStats)
+    } while (nextPageToken)
+
+    return allChannelsStats
   }
 
   async getVerifiedChannel(
@@ -470,7 +511,7 @@ export class YoutubeClient implements IYoutubeApi {
     do {
       const nextPage = await youtube.playlistItems
         .list({
-          part: ['contentDetails', 'snippet', 'id', 'status'],
+          part: ['contentDetails'],
           playlistId: channel.uploadsPlaylistId,
           maxResults: 50,
           pageToken: nextPageToken ?? undefined,
@@ -483,9 +524,21 @@ export class YoutubeClient implements IYoutubeApi {
         })
         nextPageToken = nextPage.data.nextPageToken ?? ''
 
-      const page = this.mapVideos(nextPage.data.items ?? [], channel)
-      videos = [...videos, ...page]
-      console.log('videos.length   <   max', videos.length, limit, channel.joystreamChannelId)
+        const videoIds = nextPage.data.items?.flatMap(item => item.contentDetails?.videoId ? [item.contentDetails.videoId] : []) || []
+        if (videoIds.length) {
+          const videosPage = await youtube.videos.list({
+            id: videoIds,
+            part: ['id', 'status', 'snippet', 'statistics', 'fileDetails', 'contentDetails', 'liveStreamingDetails'],
+            maxResults: 50
+          }).catch((err) => {
+            if (err instanceof FetchError && err.code === 'ENOTFOUND') {
+              throw new YoutubeApiError(ExitCodes.YoutubeApi.YOUTUBE_API_NOT_CONNECTED, err.message)
+            }
+            throw err
+          })
+          const page = this.mapVideos(videosPage.data.items || [], channel)
+          videos = [...videos, ...page]
+        }
     } while (nextPageToken && videos.length < limit)
     return videos
   }
@@ -529,13 +582,13 @@ export class YoutubeClient implements IYoutubeApi {
     )
   }
 
-  private mapVideos(videos: Schema$PlaylistItem[], channel: YtChannel): YtVideo[] {
+  private mapVideos(videos: Schema$Video[], channel: YtChannel): YtVideo[] {
     return (
       videos
         .map(
           (video) =>
             <YtVideo>{
-              id: video.contentDetails?.videoId,
+              id: video.id,
               description: video.snippet?.description,
               title: video.snippet?.title,
               channelId: video.snippet?.channelId,
@@ -545,19 +598,19 @@ export class YoutubeClient implements IYoutubeApi {
                 standard: video.snippet?.thumbnails?.standard?.url,
                 default: video.snippet?.thumbnails?.default?.url,
               },
-              url: `https://youtube.com/watch?v=${video.snippet?.resourceId?.videoId}`,
+              url: `https://youtube.com/watch?v=${video.id}`,
               publishedAt: video.snippet?.publishedAt,
               createdAt: new Date(),
               category: channel.videoCategoryId,
               languageIso: channel.joystreamChannelLanguageIso,
               privacyStatus: video.status?.privacyStatus,
-              ytRating: undefined,
-              liveBroadcastContent: 'none',
-              license: 'creativeCommon',
-              duration: 0,
-              container: '',
-              uploadStatus: 'processed',
-              viewCount: 0,
+              ytRating: video.contentDetails?.contentRating?.ytRating,
+              liveBroadcastContent: video.snippet?.liveBroadcastContent,
+              license: video.status?.license,
+              duration: toSeconds(parse(video.contentDetails?.duration ?? 'PT0S')),
+              container: video.fileDetails?.container,
+              uploadStatus: video.status?.uploadStatus,
+              viewCount: parseInt(video.statistics?.viewCount ?? '0'),
               state: 'New',
             }
         )
@@ -701,6 +754,19 @@ class QuotaMonitoringClient implements IQuotaMonitoringClient, IYoutubeApi {
 
     // increase used quota count by 1 because only one page is returned
     await this.increaseUsedQuota({ syncQuotaIncrement: 1 })
+
+    return channels
+  }
+
+  async getChannelsStats(ids: string[]) {
+    // ensure have some left api quota
+    await this.ensureYoutubeQuota()
+
+    // get channels from api
+    const channels = await this.decorated.getChannelsStats(ids)
+
+    // increase used quota count, 1 api call is being used per page of 50 channels
+    await this.increaseUsedQuota({ syncQuotaIncrement: Math.ceil(ids.length / 50) })
 
     return channels
   }

--- a/src/services/youtube/api.ts
+++ b/src/services/youtube/api.ts
@@ -237,7 +237,7 @@ export class YoutubeClient implements IYoutubeApi {
       return new youtube_v3.Youtube({ auth })
     }
     
-    return new youtube_v3.Youtube({ key: this.config.youtube.apiKey })
+    return new youtube_v3.Youtube({ auth: this.config.youtube.apiKey })
   }
 
   private async getAccessToken(

--- a/src/types/generated/ConfigJson.d.ts
+++ b/src/types/generated/ConfigJson.d.ts
@@ -196,6 +196,10 @@ export interface YoutubeOauth2ClientConfiguration {
    */
   clientSecret: string
   /**
+   * Youtube API key used for the purpose retrieving public data
+   */
+  apiKey?: string
+  /**
    * Maximum percentage of daily Youtube API quota that can be used by the Periodic polling service. Once this limit is reached the service will stop polling for new videos until the next day(when Quota resets). All the remaining quota (100 - maxAllowedQuotaUsageInPercentage) will be used for potential channel's signups.
    */
   maxAllowedQuotaUsageInPercentage?: number


### PR DESCRIPTION
- Polling: fetch channels in batches using public YouTube API and only schedule channels in which `videoCount` has changed since the last cycle for video ingestion (to limit the number of API requests)
- Polling: `iterateVideos` will now make additional call to `videos` endpoint of the YouTube API to retrieve `Schema$Video` objects instead of `Schema$PlaylistItem`. This provides additional details such as `duration`, which are required for payouts and some other functionalities to function properly.
- Polling: remove `lastPolledChannelId` workaround 
- Logging: normalize errors when logging to elasticsearch to avoid mapping issues
- Logging: Switch from using `console.log`'s to `logger` in a few places