### PR TITLE
Re-enable sign-ups, add `preOptOutStatus`

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -56,7 +56,7 @@ aws:
 httpApi:
   port: 3001
   ownerKey: ypp-owner-key
-  disableNewSignUps: true
+  disableNewSignUps: false
 joystream:
   faucet:
     endpoint: http://localhost:3002/register

--- a/src/repository/channel.ts
+++ b/src/repository/channel.ts
@@ -164,6 +164,12 @@ function createChannelModel(tablePrefix: ResourcePrefix) {
         enum: channelYppStatus,
       },
 
+      // Channel's YPP program participation status before the opt-out bug (ref: https://github.com/Joystream/youtube-synch/issues/337)
+      preOptOutStatus: {
+        type: String,
+        enum: channelYppStatus,
+      },
+
       phantomKey: {
         type: String,
         index: {
@@ -287,6 +293,7 @@ export class ChannelsRepository implements IRepository<YtChannel> {
       let lastKey = undefined
       const results = []
       do {
+        // FIXME: Is this the reason why /channels returns ALL channels?
         let queriedBatch: QueryResponse<AnyItem> = await f(this.model.query(init))
           .startAt(lastKey as any)
           .exec()

--- a/src/services/httpApi/controllers/channels.ts
+++ b/src/services/httpApi/controllers/channels.ts
@@ -120,7 +120,7 @@ export class ChannelsController {
         ...(existingChannel
           ? {
               ...existingChannel,
-              yppStatus: 'Unverified',
+              yppStatus: existingChannel.preOptOutStatus || 'Unverified',
               userAccessToken: channel.userAccessToken,
               userRefreshToken: channel.userRefreshToken,
             }

--- a/src/services/httpApi/controllers/channels.ts
+++ b/src/services/httpApi/controllers/channels.ts
@@ -41,6 +41,7 @@ import {
   VerifyChannelDto,
   WhitelistChannelDto,
 } from '../dtos'
+import { Logger } from 'winston'
 
 @Controller('channels')
 @ApiTags('channels')
@@ -51,7 +52,8 @@ export class ChannelsController {
     private qnApi: QueryNodeApi,
     private dynamodbService: DynamodbService,
     private youtubePollingService: YoutubePollingService,
-    private contentProcessingClient: ContentProcessingClient
+    private contentProcessingClient: ContentProcessingClient,
+    private logger: Logger
   ) {}
 
   @Post()
@@ -130,6 +132,13 @@ export class ChannelsController {
         videoCategoryId,
         referrerChannelId,
         joystreamChannelLanguageIso,
+      }
+
+      if (existingChannel && existingChannel.preOptOutStatus) {
+        this.logger.info(
+          `Automatically assigned previous ${existingChannel.preOptOutStatus} tier ` +
+          `to channel ${joystreamChannelId} (${existingChannel.id})`
+        )
       }
 
       // save user and channel

--- a/src/services/httpApi/dtos.ts
+++ b/src/services/httpApi/dtos.ts
@@ -113,6 +113,7 @@ export class ChannelDto {
   @ApiProperty() description: string
   @ApiProperty() shouldBeIngested: boolean
   @ApiProperty({ enum: channelYppStatus }) yppStatus: ChannelYppStatus
+  @ApiProperty({ enum: channelYppStatus }) preOptOutStatus: ChannelYppStatus
   @ApiProperty() joystreamChannelId: number
   @ApiProperty() referrerChannelId?: number
   @ApiProperty() videoCategoryId: string
@@ -133,6 +134,7 @@ export class ChannelDto {
     this.language = channel.language
     this.shouldBeIngested = channel.shouldBeIngested
     this.yppStatus = channel.yppStatus
+    this.preOptOutStatus = channel.preOptOutStatus
     this.thumbnails = channel.thumbnails
     this.createdAt = new Date(channel.createdAt)
     this.syncStatus = new ChannelSyncStatusDto(syncStatus)

--- a/src/services/httpApi/main.ts
+++ b/src/services/httpApi/main.ts
@@ -25,6 +25,7 @@ import {
 } from './controllers'
 import { MembershipController } from './controllers/membership'
 import { ReferrersController } from './controllers/referrers'
+import { Logger } from 'winston'
 
 class ApiModule {}
 
@@ -70,6 +71,7 @@ export async function bootstrapHttpApi(
   await cryptoWaitReady()
 
   const dynamodbService = new DynamodbService(config.aws, false)
+  const logger = logging.createLogger('HttpApi')
 
   const objectAppModule: DynamicModule = {
     module: ApiModule,
@@ -104,6 +106,10 @@ export async function bootstrapHttpApi(
       {
         provide: ContentProcessingClient,
         useValue: contentProcessingClient,
+      },
+      {
+        provide: Logger,
+        useValue: logger,
       },
       {
         provide: 'youtube',
@@ -146,7 +152,6 @@ export async function bootstrapHttpApi(
   })
 
   // API request/response logging
-  const logger = logging.createLogger('HttpApi')
   app.use((request: express.Request, response: express.Response, next: express.NextFunction) => {
     const { method, originalUrl } = request
 

--- a/src/types/youtube.ts
+++ b/src/types/youtube.ts
@@ -96,6 +96,9 @@ export class YtChannel {
   // This field serves the purpose of nonce to avoid playback attacks
   lastActedAt: Date
 
+  // Channel's status before opt-out issue (ref: https://github.com/Joystream/youtube-synch/issues/337)
+  preOptOutStatus: ChannelYppStatus
+
   // Timestamp when the channel verification was processed, either to Verified or Suspended
   processedAt: Date
 

--- a/ypp-operations/src/types.ts
+++ b/ypp-operations/src/types.ts
@@ -230,6 +230,21 @@ export type HubspotYPPContact = {
    * Synced video category name
    */
   synccategoryname: string
+
+  /**
+   * OPT-OUT BUG PROPS
+   * (ref: https://github.com/Joystream/youtube-synch/issues/337) 
+   */
+
+  /**
+   * Date and time when the channel was opted-out due to a bug.
+   */
+  opt_out_bug_date: string
+
+  /**
+   * Status that the channel had before being opted-out.
+   */
+  pre_opt_out_status: ChannelYppStatus
 }
 
 export const payableContactProps = [


### PR DESCRIPTION
- Re-enable YPP sign-ups in the API
- Add channel's DynamoDB `preOptOutStatus` field support. This field holds the status/tier that the channel had before being opted out due to https://github.com/Joystream/youtube-synch/issues/337.
- Add HubSpot `pre_opt_out_status` and `opt_out_bug_date` fields support 
- Add `preOptOutStatus` field to `GET /channels/:joystreamChannelId` output
- **Assign `preOptOutStatus` automatically on `POST /channels`** (ie. automatically restore previous tiers of opted-out creators after they sign-up again)

**Scripts used for marking opted-out channels in HubSpot and DynamoDB can be found [here](https://github.com/Joystream/youtube-synch/commit/317a5642f900421b31ac8bae6241149ea5fb6696)**