### PR TITLE
Improved proxy setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,9 @@ COPY package.json package-lock.json ./
 # Install dependencies
 RUN npm install
 
+# Force-update yt-dlp
+RUN node ./node_modules/youtube-dl-exec/scripts/postinstall.js
+
 # Copy the rest of your application
 COPY . .
 

--- a/config.yml
+++ b/config.yml
@@ -47,6 +47,7 @@ youtube:
 # proxy:
 #   urls:
 #     ["socks5://proxy1:1080", "socks5://proxy2:1080"]
+#   banDuration: 14400 # 4 hours
 aws:
   endpoint: http://localhost:4566
   region: us-east-1

--- a/config.yml
+++ b/config.yml
@@ -52,7 +52,7 @@ youtube:
 #   waitInterval: 60
 #   chain:
 #      url: socks5://proxy.chain:1080
-#      configPath: /etc/proxychains4.conf
+#      configDir: /etc
 aws:
   endpoint: http://localhost:4566
   region: us-east-1

--- a/config.yml
+++ b/config.yml
@@ -46,8 +46,13 @@ youtube:
   # maxAllowedQuotaUsageInPercentage: 95
 # proxy:
 #   urls:
-#     ["socks5://proxy1:1080", "socks5://proxy2:1080"]
-#   banDuration: 14400 # 4 hours
+#     - socks5://proxy1:1080
+#     - socks5://proxy2:1080
+#   exclusionDuration: 14400
+#   waitInterval: 60
+#   chain:
+#      url: socks5://proxy.chain:1080
+#      configPath: /etc/proxychains4.conf
 aws:
   endpoint: http://localhost:4566
   region: us-east-1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,7 +61,6 @@ services:
       # - /var/run/docker.sock:/var/run/docker.sock
       - ./local/logs:/youtube-synch/local/logs
       - ./local/data:/youtube-synch/local/data
-      - ./proxychains4.conf:/etc/proxychains4.conf
       # mount Google Cloud's Application Default Credentials file. A default bind mount is created
       # as workaround for scenario when `YT_SYNCH__YOUTUBE__ADC_KEY_FILE_PATH` will be undefined,
       # since docker-compose does not support creating bind-mount volume with empty path.

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,6 +81,7 @@
         "reflect-metadata": "^0.1.13",
         "rxjs": "^7.5.2",
         "sleep-promise": "^9.1.0",
+        "socks-proxy-agent": "^8.0.5",
         "swagger-ui-express": "^4.3.0",
         "uuid": "^9.0.0",
         "winston": "^3.8.2",
@@ -25905,25 +25906,22 @@
       }
     },
     "node_modules/socks-proxy-agent": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.3.tgz",
-      "integrity": "sha512-VNegTZKhuGq5vSD6XNKlbqWhyt/40CgoEw8XxD6dhnm8Jq9IEa3nIa4HwnM8XOqU0CdB0BwWVXusqiFXfHB3+A==",
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
       "dependencies": {
-        "agent-base": "^7.1.1",
+        "agent-base": "^7.1.2",
         "debug": "^4.3.4",
-        "socks": "^2.7.1"
+        "socks": "^2.8.3"
       },
       "engines": {
         "node": ">= 14"
       }
     },
     "node_modules/socks-proxy-agent/node_modules/agent-base": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
-      "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
-      "dependencies": {
-        "debug": "^4.3.4"
-      },
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
       "engines": {
         "node": ">= 14"
       }

--- a/package.json
+++ b/package.json
@@ -140,6 +140,7 @@
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.5.2",
     "sleep-promise": "^9.1.0",
+    "socks-proxy-agent": "^8.0.5",
     "swagger-ui-express": "^4.3.0",
     "uuid": "^9.0.0",
     "winston": "^3.8.2",

--- a/proxychains4.conf
+++ b/proxychains4.conf
@@ -6,4 +6,4 @@ tcp_connect_time_out 8000
 
 [ProxyList]
 
-socks5 	172.20.0.2 1080
+; socks5 	{PROXYCHAIN_HOST} {PROXYCHAIN_PORT}

--- a/proxychains4.conf
+++ b/proxychains4.conf
@@ -1,9 +1,0 @@
-strict_chain
-quiet_mode
-
-tcp_read_time_out 15000
-tcp_connect_time_out 8000
-
-[ProxyList]
-
-; socks5 	{PROXYCHAIN_HOST} {PROXYCHAIN_PORT}

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -83,6 +83,9 @@ export class Service {
     if (this.config.logs?.file) {
       this.checkConfigDir('logs.file.path', this.config.logs.file.path)
     }
+    if (this.config.proxy?.chain) {
+      this.checkConfigDir('proxy.chain.configPath', this.config.proxy.chain.configPath)
+    }
   }
 
   private async startSync(): Promise<void> {

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -38,7 +38,7 @@ export class Service {
     this.socks5ProxyService = config.proxy ? new Socks5ProxyService(config.proxy, this.logging) : undefined
     this.queryNodeApi = new QueryNodeApi(config.endpoints.queryNode, this.logging)
     this.dynamodbService = new DynamodbService(this.config.aws)
-    this.youtubeApi = YoutubeApi.create(this.config, this.dynamodbService.repo.stats, this.logging)
+    this.youtubeApi = YoutubeApi.create(this.config, this.dynamodbService.repo.stats, this.logging, this.socks5ProxyService)
     this.runtimeApi = new RuntimeApi(config.endpoints.joystreamNodeWs, this.logging)
     this.joystreamClient = new JoystreamClient(config, this.runtimeApi, this.queryNodeApi, this.logging)
     this.contentProcessingClient = new ContentProcessingClient({ ...config.sync, ...config.endpoints })

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -75,16 +75,13 @@ export class Service {
     if (this.config.sync.enable) {
       this.checkConfigDir('sync.downloadsDir', this.config.sync.downloadsDir)
       const thumbsDir = path.join(this.config.sync.downloadsDir, THUMBNAILS_SUBDIR)
-      if (!fs.existsSync(thumbsDir)) {
-        fs.mkdirSync(thumbsDir)
-      }
       this.checkConfigDir('thumbnails', thumbsDir)
     }
     if (this.config.logs?.file) {
       this.checkConfigDir('logs.file.path', this.config.logs.file.path)
     }
     if (this.config.proxy?.chain) {
-      this.checkConfigDir('proxy.chain.configPath', this.config.proxy.chain.configPath)
+      this.checkConfigDir('proxy.chain.configDir', this.config.proxy.chain.configDir)
     }
   }
 

--- a/src/cli/commands/downloadVideo.ts
+++ b/src/cli/commands/downloadVideo.ts
@@ -16,7 +16,8 @@ export default class DownloadVideo extends DefaultCommandBase {
         description: 'YouTube video url(s) of the video(s) to be downloaded'
     }),
     skipProxy: flags.boolean({
-        description: 'Skip proxy even if configured.'
+        description: 'Skip proxy even if configured.',
+        default: false,
     }),
     ...DefaultCommandBase.flags,
   }

--- a/src/cli/commands/downloadVideo.ts
+++ b/src/cli/commands/downloadVideo.ts
@@ -38,14 +38,14 @@ export default class DownloadVideo extends DefaultCommandBase {
     const proxyService = proxyConfig ? new Socks5ProxyService(proxyConfig, logging) : undefined
     const youtubeClient = new YoutubeClient(this.appConfig, logging, proxyService)
     for (const videoUrl of videoUrls) {
-        const checkResp = await youtubeClient.checkVideo(videoUrl)
-        this.log(`Downloading ${videoUrl}...`)
-        this.log('Selected format: ', checkResp.format)
-        this.log('Expected size: ', checkResp.filesize_approx)
         const proxy = await proxyService?.getProxy(videoUrl)
         if (proxy) {
             this.log(`Selected proxy: ${proxy}`)
         }
+        const checkResp = await youtubeClient.checkVideo(videoUrl, proxy)
+        this.log(`Downloading ${videoUrl}...`)
+        this.log(`Selected format: ${checkResp.format}`)
+        this.log(`Expected size: ${checkResp.filesize_approx}`)
         const downloadResp = await youtubeClient.downloadVideo(videoUrl, downloadsDir, proxy)
         assert(
             fs.existsSync(path.join(downloadsDir, `${downloadResp.id}.${downloadResp.ext}`)),

--- a/src/cli/commands/downloadVideo.ts
+++ b/src/cli/commands/downloadVideo.ts
@@ -1,0 +1,62 @@
+import { flags } from '@oclif/command'
+import fs from 'fs'
+import path from 'path'
+import DefaultCommandBase from '../base/default'
+import { LoggingService } from '../../services/logging'
+import { YoutubeClient } from '../../services/youtube/api'
+import { Socks5ProxyService } from '../../services/proxy/Socks5ProxyService'
+import assert from 'assert'
+
+export default class DownloadVideo extends DefaultCommandBase {
+  static description = 'Perform a test video download.'
+
+  static flags = {
+    url: flags.string({
+        multiple: true,
+        description: 'YouTube video url(s) of the video(s) to be downloaded'
+    }),
+    skipProxy: flags.boolean({
+        description: 'Skip proxy even if configured.'
+    }),
+    ...DefaultCommandBase.flags,
+  }
+
+  async run(): Promise<void> {
+    const { url: videoUrls, skipProxy } = this.parse(DownloadVideo).flags
+
+    const { downloadsDir } = this.appConfig.sync 
+    assert(downloadsDir, "Download dir needs to be specified!")
+
+    const logging = LoggingService.withCLIConfig()
+    let proxyConfig = this.appConfig.proxy
+    if (skipProxy) {
+        proxyConfig = undefined
+        this.log('Skipping proxy setup...')
+    } else {
+        this.log('Using proxy configuration:', proxyConfig)
+    }
+    const proxyService = proxyConfig ? new Socks5ProxyService(proxyConfig, logging) : undefined
+    const youtubeClient = new YoutubeClient(this.appConfig, logging, proxyService)
+    for (const videoUrl of videoUrls) {
+        const checkResp = await youtubeClient.checkVideo(videoUrl)
+        this.log(`Downloading ${videoUrl}...`)
+        this.log('Selected format: ', checkResp.format)
+        this.log('Expected size: ', checkResp.filesize_approx)
+        const proxy = await proxyService?.getProxy(videoUrl)
+        if (proxy) {
+            this.log(`Selected proxy: ${proxy}`)
+        }
+        const downloadResp = await youtubeClient.downloadVideo(videoUrl, downloadsDir, proxy)
+        assert(
+            fs.existsSync(path.join(downloadsDir, `${downloadResp.id}.${downloadResp.ext}`)),
+            'Download error: File not found'
+        )
+        proxyService?.unbindProxy(downloadResp.id)
+    }
+    this.log("All videos successfully downloaded!")
+  }
+
+  async finally(): Promise<void> {
+    /* Do nothing */
+  }
+}

--- a/src/schemas/config.ts
+++ b/src/schemas/config.ts
@@ -228,11 +228,21 @@ export const configSchema: JSONSchema7 = objectSchema({
       title: 'Socks5 proxy client configuration used by yt-dlp to bypass IP blockage by Youtube',
       description: 'Socks5 proxy client configuration used by yt-dlp to bypass IP blockage by Youtube',
       properties: {
-        chainThrough: {
-          description: 'Url of the socks5 proxy through which all requests should be chained (if required to access other proxies).',
-          type: 'string',
-          pattern: '^socks5://'
-        },
+        chain: objectSchema({
+          title: 'Socks5 proxy chaining configuration',
+          properties: {
+            url: {
+              description: 'Url of the socks5 proxy that all other proxy requests will be chained through.',
+              type: 'string',
+              pattern: '^socks5://'
+            },
+            configPath: {
+              description: 'Absolute path to a location where proxychains.conf file will be stored',
+              type: 'string'
+            },
+          },
+          required: ['url', 'configPath']
+        }),
         urls: {
           description: 'List of available socks5 proxy URLs',
           type: 'array',
@@ -246,12 +256,10 @@ export const configSchema: JSONSchema7 = objectSchema({
         waitInterval: {
           description: 'How long should the application wait in case no proxies are available (in seconds)',
           type: 'integer',
-          default: 60
         },
         exclusionDuration: {
           description: `How long should the proxy remain excluded in case it's blocked (in seconds)`,
           type: 'integer',
-          default: 24 * 60 * 60
         }
       },
       required: ['urls', 'exclusionDuration', 'waitInterval'],

--- a/src/schemas/config.ts
+++ b/src/schemas/config.ts
@@ -236,12 +236,12 @@ export const configSchema: JSONSchema7 = objectSchema({
               type: 'string',
               pattern: '^socks5://'
             },
-            configPath: {
-              description: 'Absolute path to a location where proxychains.conf file will be stored',
+            configDir: {
+              description: 'Absolute path to a location where proxychains4.conf file will be stored',
               type: 'string'
             },
           },
-          required: ['url', 'configPath']
+          required: ['url', 'configDir']
         }),
         urls: {
           description: 'List of available socks5 proxy URLs',

--- a/src/schemas/config.ts
+++ b/src/schemas/config.ts
@@ -228,17 +228,33 @@ export const configSchema: JSONSchema7 = objectSchema({
       title: 'Socks5 proxy client configuration used by yt-dlp to bypass IP blockage by Youtube',
       description: 'Socks5 proxy client configuration used by yt-dlp to bypass IP blockage by Youtube',
       properties: {
+        chainThrough: {
+          description: 'Url of the socks5 proxy through which all requests should be chained (if required to access other proxies).',
+          type: 'string',
+          pattern: '^socks5://'
+        },
         urls: {
           description: 'List of available socks5 proxy URLs',
           type: 'array',
           items: {
-            description: 'Socks5 proxy url, e.g. ["socks://localhost:1080"]',
+            description: 'Socks5 proxy url, e.g. ["socks5://localhost:1080"]',
             type: 'string',
+            pattern: '^socks5://'
           },
           minItems: 1,
+        },
+        waitInterval: {
+          description: 'How long should the application wait in case no proxies are available (in seconds)',
+          type: 'integer',
+          default: 60
+        },
+        exclusionDuration: {
+          description: `How long should the proxy remain excluded in case it's blocked (in seconds)`,
+          type: 'integer',
+          default: 24 * 60 * 60
         }
       },
-      required: [],
+      required: ['urls', 'exclusionDuration', 'waitInterval'],
     }),
 
     creatorOnboardingRequirements: objectSchema({

--- a/src/scripts/downloadAsset.ts
+++ b/src/scripts/downloadAsset.ts
@@ -9,47 +9,46 @@ import { createWriteStream } from 'fs'
 export const SCRIPT_PATH = __filename
 
 function validateArgs() {
-    try {
-        const assetUrl = new URL(argv[2])
-        assert(assetUrl.protocol === 'http' || assetUrl.protocol === 'https', `Invalid assetUrl protocol: ${assetUrl.protocol}`)
+  try {
+    const assetUrl = new URL(argv[2])
+    assert(assetUrl.protocol === 'http:' || assetUrl.protocol === 'https:', `Invalid assetUrl protocol: ${assetUrl.protocol}`)
 
-        const destPath = argv[3]
-        if (!path.isAbsolute(destPath)) {
-            throw new Error('destPath must be absolute!')
-        }
-
-        let proxyUrl: URL | undefined = undefined
-        if (argv[4]) {
-            proxyUrl = new URL(argv[4])
-            assert(proxyUrl.protocol === 'socks5', `Invalid proxyUrl protocol: ${proxyUrl.protocol}`)
-        }
-
-
-        return { assetUrl: assetUrl.toString(), destPath, proxyUrl: proxyUrl?.toString() }
-    } catch (e: any) {
-        throw new Error(`Invalid arguments: ${e.toString()}`)
+    const destPath = argv[3]
+    if (!path.isAbsolute(destPath) || !path.extname(destPath)) {
+      throw new Error('destPath must be an absolute path to a file!')
     }
+
+    let proxyUrl: URL | undefined = undefined
+    if (argv[4]) {
+      proxyUrl = new URL(argv[4])
+      assert(proxyUrl.protocol === 'socks5:', `Invalid proxyUrl protocol: ${proxyUrl.protocol}`)
+    }
+
+    return { assetUrl: assetUrl.toString(), destPath, proxyUrl: proxyUrl?.toString() }
+  } catch (e: any) {
+    throw new Error(`Invalid arguments: ${e.toString()}`)
+  }
 }
 
 async function main() {
-    const { assetUrl, destPath, proxyUrl } = validateArgs()
-    const reqConfig: AxiosRequestConfig<any> = { responseType: 'stream' }
-    if (proxyUrl) {
-      const proxyAgent = new SocksProxyAgent(proxyUrl)
-      reqConfig.httpAgent = proxyAgent
-      reqConfig.httpsAgent = proxyAgent
-    }
-    const response = await axios.get<Readable>(assetUrl, reqConfig)
-    const writeStream = createWriteStream(destPath)
-    await streamPromise.pipeline([response.data, writeStream])
+  const { assetUrl, destPath, proxyUrl } = validateArgs()
+  const reqConfig: AxiosRequestConfig<any> = { responseType: 'stream' }
+  if (proxyUrl) {
+    const proxyAgent = new SocksProxyAgent(proxyUrl)
+    reqConfig.httpAgent = proxyAgent
+    reqConfig.httpsAgent = proxyAgent
+  }
+  const response = await axios.get<Readable>(assetUrl, reqConfig)
+  const writeStream = createWriteStream(destPath)
+  await streamPromise.pipeline([response.data, writeStream])
 }
 
 // Execute script only if the file was executed directly (not imported as module)
 if (require.main === module) {
-    main()
-        .then(() => process.exit(0))
-        .catch(e => {
-            console.error(e)
-            process.exit(1)
-        })
+  main()
+    .then(() => process.exit(0))
+    .catch(e => {
+      console.error(e)
+      process.exit(1)
+    })
 }

--- a/src/scripts/downloadAsset.ts
+++ b/src/scripts/downloadAsset.ts
@@ -6,7 +6,11 @@ import { Readable, promises as streamPromise } from 'stream'
 import path from 'path'
 import { createWriteStream } from 'fs'
 
-export const SCRIPT_PATH = __filename
+const isTS =  path.extname(__filename) === '.ts'
+export const SCRIPT_PATH = __filename.split(path.sep)
+  .map((part) => part === 'src' ? 'lib' : part)
+  .join(path.sep)
+  .replace('.ts', '.js')
 
 function validateArgs() {
   try {
@@ -44,7 +48,7 @@ async function main() {
 }
 
 // Execute script only if the file was executed directly (not imported as module)
-if (require.main === module) {
+if (require.main === module && !isTS) {
   main()
     .then(() => process.exit(0))
     .catch(e => {

--- a/src/scripts/downloadAsset.ts
+++ b/src/scripts/downloadAsset.ts
@@ -1,0 +1,55 @@
+import axios, { AxiosRequestConfig } from 'axios'
+import assert from 'assert'
+import { argv } from 'process'
+import { SocksProxyAgent } from 'socks-proxy-agent'
+import { Readable, promises as streamPromise } from 'stream'
+import path from 'path'
+import { createWriteStream } from 'fs'
+
+export const SCRIPT_PATH = __filename
+
+function validateArgs() {
+    try {
+        const assetUrl = new URL(argv[2])
+        assert(assetUrl.protocol === 'http' || assetUrl.protocol === 'https', `Invalid assetUrl protocol: ${assetUrl.protocol}`)
+
+        const destPath = argv[3]
+        if (!path.isAbsolute(destPath)) {
+            throw new Error('destPath must be absolute!')
+        }
+
+        let proxyUrl: URL | undefined = undefined
+        if (argv[4]) {
+            proxyUrl = new URL(argv[4])
+            assert(proxyUrl.protocol === 'socks5', `Invalid proxyUrl protocol: ${proxyUrl.protocol}`)
+        }
+
+
+        return { assetUrl: assetUrl.toString(), destPath, proxyUrl: proxyUrl?.toString() }
+    } catch (e: any) {
+        throw new Error(`Invalid arguments: ${e.toString()}`)
+    }
+}
+
+async function main() {
+    const { assetUrl, destPath, proxyUrl } = validateArgs()
+    const reqConfig: AxiosRequestConfig<any> = { responseType: 'stream' }
+    if (proxyUrl) {
+      const proxyAgent = new SocksProxyAgent(proxyUrl)
+      reqConfig.httpAgent = proxyAgent
+      reqConfig.httpsAgent = proxyAgent
+    }
+    const response = await axios.get<Readable>(assetUrl, reqConfig)
+    const writeStream = createWriteStream(destPath)
+    await streamPromise.pipeline([response.data, writeStream])
+}
+
+// Execute script only if the file was executed directly (not imported as module)
+if (require.main === module) {
+    main()
+        .then(() => process.exit(0))
+        .catch(e => {
+            console.error(e)
+            process.exit(1)
+        })
+}

--- a/src/services/logging/LoggingService.ts
+++ b/src/services/logging/LoggingService.ts
@@ -48,8 +48,8 @@ const cliErrorFormat: (opts: CLIErrorFormatOpts) => Format = winston.format((inf
   if (!info[fieldName]) {
     return info
   }
-  const formatter = winston.format.errors({ stack: true })
-  info[fieldName] = formatter.transform(info[fieldName], formatter.options)
+  const err = info[fieldName]
+  info[fieldName] = err instanceof Error ? `${err.name}: ${err.message}` : err
   return info
 })
 

--- a/src/services/proxy/Socks5ProxyService.ts
+++ b/src/services/proxy/Socks5ProxyService.ts
@@ -5,6 +5,7 @@ import { LoggingService } from "../logging"
 import sleep from "sleep-promise"
 import AsyncLock from "async-lock"
 import { ReadonlyConfig } from "../../types"
+import _ from 'lodash'
 
 export class Socks5ProxyService {
   private readonly logger: Logger
@@ -71,11 +72,11 @@ export class Socks5ProxyService {
 
   private async bindProxy(jobId: string): Promise<string> {
     return this.asyncLock.acquire(this.BIND_LOCK_ID, async () => {
-      let [selectedProxy] = this.availableProxies
+      let selectedProxy = _.sample(this.availableProxies)
       while (!selectedProxy) {
         this.logger.debug(`No proxy endpoints available, waiting ${this.config.waitInterval}s...`, { jobId })
         await sleep(this.config.waitInterval * 1_000)
-        selectedProxy = this.availableProxies[0]
+        selectedProxy = _.sample(this.availableProxies)
       }
       this.proxyByJobIdCache.set(jobId, selectedProxy)
       this.logger.debug(`Proxy ${selectedProxy} bound to job`, { jobId })

--- a/src/services/proxy/Socks5ProxyService.ts
+++ b/src/services/proxy/Socks5ProxyService.ts
@@ -1,0 +1,91 @@
+import { Logger } from "winston"
+import NodeCache from 'node-cache'
+import { LoggingService } from "../logging"
+import sleep from "sleep-promise"
+import AsyncLock from "async-lock"
+import { ReadonlyConfig } from "../../types"
+
+export class Socks5ProxyService {
+  private readonly logger: Logger
+  private proxyByJobIdCache: Map<string, string>
+  private faulyProxiesCache: NodeCache
+  private asyncLock: AsyncLock
+  private _proxychainExec: string | undefined
+  private readonly BIND_LOCK_ID = 'proxy_bind'
+
+  public constructor(
+    private config: NonNullable<ReadonlyConfig['proxy']>,
+    logging: LoggingService,
+  ) {
+    const proxiesNum = this.config.urls.length
+    this.proxyByJobIdCache = new Map()
+    this.faulyProxiesCache = new NodeCache({
+      stdTTL: this.config.exclusionDuration,
+      deleteOnExpire: true,
+      maxKeys: proxiesNum
+    })
+    this.asyncLock = new AsyncLock({ maxPending: proxiesNum * 10 })
+    this.logger = logging.createLogger('Socks5ProxyService')
+    if (this.config.chainThrough) {
+      try {
+        const chainThroughUrl = new URL(this.config.chainThrough)
+        this._proxychainExec = [
+          `PROXYCHAINS_SOCKS5_HOST=${chainThroughUrl.host}`,
+          `PROXYCHAINS_SOCKS5_PORT=${chainThroughUrl.port}`,
+          'proxychains'
+        ].join(' ')
+      } catch (e) {
+        throw new Error(`Invalid config.proxy.chainThrough URL: ${this.config.chainThrough}`)
+      }
+    }
+  }
+
+  private get availableProxies(): string[] {
+    return this.config.urls.filter((url) => (
+      !this.faulyProxiesCache.has(url) && !this.proxyByJobIdCache.has(url)
+    ))
+  }
+
+  public get proxychainExec(): string | undefined {
+    return this._proxychainExec
+  }
+
+  private async bindProxy(jobId: string): Promise<string> {
+    return this.asyncLock.acquire(this.BIND_LOCK_ID, async () => {
+      let [selectedProxy] = this.availableProxies
+      while (!selectedProxy) {
+        this.logger.debug(`No proxy endpoints available, waiting ${this.config.waitInterval}s...`, { jobId })
+        await sleep(this.config.waitInterval * 1_000)
+        selectedProxy = this.availableProxies[0]
+      }
+      this.proxyByJobIdCache.set(jobId, selectedProxy)
+      this.logger.debug(`Proxy ${selectedProxy} bound to job`, { jobId })
+      return selectedProxy
+    })
+  }
+
+  public async getProxy(jobId: string): Promise<string> {
+    const cachedProxy = this.proxyByJobIdCache.get(jobId)
+    if (cachedProxy) {
+      return cachedProxy
+    }
+    const proxyUrl = await this.bindProxy(jobId)
+    return proxyUrl
+  }
+
+  public unbindProxy(jobId: string): string | undefined {
+    const cachedProxy = this.proxyByJobIdCache.get(jobId)
+    this.proxyByJobIdCache.delete(jobId)
+    if (cachedProxy) {
+      this.logger.debug(`Proxy ${cachedProxy} unbound`, { jobId })
+    } else {
+      this.logger.debug(`No proxy to unbind`, { jobId })
+    }
+    return cachedProxy
+  }
+
+  public reportFaultyProxy(url: string) {
+    this.logger.warn(`Faulty proxy reported: ${url}`)
+    this.faulyProxiesCache.set(url, true)
+  }
+}

--- a/src/services/proxy/Socks5ProxyService.ts
+++ b/src/services/proxy/Socks5ProxyService.ts
@@ -33,6 +33,7 @@ export class Socks5ProxyService {
       const configFilePath = this.initProxychainsConfig(this.config.chain.url, this.config.chain.configDir)
       this._proxychainExec = [
         'proxychains',
+        '-q',
         `-f ${configFilePath}`
       ].join(' ')
     }

--- a/src/services/runtime/client.ts
+++ b/src/services/runtime/client.ts
@@ -14,17 +14,15 @@ import { Bytes } from '@polkadot/types'
 import { Option } from '@polkadot/types/'
 import { PalletContentStorageAssetsRecord } from '@polkadot/types/lookup'
 import type { ISubmittableResult } from '@polkadot/types/types'
-import axios from 'axios'
 import BN from 'bn.js'
 import ffmpeg from 'fluent-ffmpeg'
 import fs from 'fs'
 import mimeTypes from 'mime-types'
 import path from 'path'
-import { Readable } from 'stream'
 import { Logger } from 'winston'
 import { ReadonlyConfig } from '../../types'
 import { ExitCodes, RuntimeApiError } from '../../types/errors'
-import { Thumbnails, YtVideo, YtVideoWithJsChannelId } from '../../types/youtube'
+import { YtVideo, YtVideoWithJsChannelId } from '../../types/youtube'
 import { AppActionSignatureInput, signAppActionCommitmentForVideo } from '../../utils/hasher'
 import { LoggingService } from '../logging'
 import { QueryNodeApi } from '../query-node/api'
@@ -223,19 +221,6 @@ export class JoystreamClient {
     const assets = prepareAssetsForExtrinsic(perMegabyteFee, dataObjectsMetadata)
 
     return { meta, assets }
-  }
-}
-
-export async function getThumbnailAsset(thumbnails: Thumbnails) {
-  try {
-    // * We are using `medium` thumbnail because it has correct aspect ratio for Atlas (16/9)
-    const response = await axios.get<Readable>(thumbnails.medium, { responseType: 'stream' })
-    return response.data
-  } catch (error) {
-    if (axios.isAxiosError(error)) {
-      throw error.toJSON()
-    }
-    throw error
   }
 }
 

--- a/src/services/storage-node/api.ts
+++ b/src/services/storage-node/api.ts
@@ -9,9 +9,9 @@ import { ExitCodes, StorageApiError } from '../../types/errors'
 import { YtVideo } from '../../types/youtube'
 import { LoggingService } from '../logging'
 import { QueryNodeApi } from '../query-node/api'
-import { getThumbnailAsset } from '../runtime/client'
 import { AssetUploadInput, StorageNodeInfo } from '../runtime/types'
 import sleep from 'sleep-promise'
+import { VideoAssetPaths } from '../syncProcessing/utils'
 
 export type OperatorInfo = { id: string; endpoint: string }
 export type OperatorsMapping = Record<string, OperatorInfo>
@@ -26,17 +26,17 @@ export class StorageNodeApi {
     this.logger = logging.createLogger('StorageNodeApi')
   }
 
-  async uploadVideo(bagId: string, video: YtVideo, videoFilePath: string, maxAttempts = 5): Promise<void> {
+  async uploadVideo(bagId: string, video: YtVideo, assetPaths: Required<VideoAssetPaths>, maxAttempts = 5): Promise<void> {
     let attempt = 1
     while (attempt <= maxAttempts) {
       const assetsInput: AssetUploadInput[] = [
         {
           dataObjectId: createType('u64', new BN(video.joystreamVideo.assetIds[0])),
-          file: fs.createReadStream(videoFilePath),
+          file: fs.createReadStream(assetPaths.video),
         },
         {
           dataObjectId: createType('u64', new BN(video.joystreamVideo.assetIds[1])),
-          file: await getThumbnailAsset(video.thumbnails),
+          file: fs.createReadStream(assetPaths.thumbnail),
         },
       ]
       try {

--- a/src/services/syncProcessing/ContentDownloadService.ts
+++ b/src/services/syncProcessing/ContentDownloadService.ts
@@ -68,27 +68,21 @@ export class ContentDownloadService {
     const videoDownloadsDir = this.config.downloadsDir
     const resolvedVideos = fs
       .readdirSync(videoDownloadsDir)
-      .map((filePath) => filePath.split('.'))
-      .filter((filePath) => filePath.length === 2)
+      .map((fileName) => fileName.split('.'))
+      .filter((fileNameParts) => fileNameParts.length === 2)
       .map(([videoId, ext]) => {
-        const filePath = path.join(this.config.downloadsDir, `${videoId}.${ext}`)
+        const filePath = path.join(videoDownloadsDir, `${videoId}.${ext}`)
         SyncUtils.setVideoAssetPath(videoId, 'video', filePath)
         SyncUtils.updateUsedStorageSize(this.fileSize(filePath))
         return videoId
       })
+    const thumbDownloadsDir = path.join(videoDownloadsDir, THUMBNAILS_SUBDIR)
     const resolvedThumbs = fs
-      .readdirSync(path.join(videoDownloadsDir, THUMBNAILS_SUBDIR))
-      .map((fileName) => {
-        const [videoId, ext] = fileName.split('.')
-        const filePath = path.join(this.config.downloadsDir, THUMBNAILS_SUBDIR, fileName)
-        if (ext.includes('.')) {
-          // Remove partially downloaded thumbnails
-          try {
-            fs.unlinkSync(filePath)
-          } catch (e: any) {
-            this.logger.warn(`Failed to remove ${filePath}: ${e.toString()}`)
-          }
-        }
+      .readdirSync(thumbDownloadsDir)
+      .map((fileName) => fileName.split('.'))
+      .filter((fileNameParts) => fileNameParts.length === 2)
+      .map(([videoId, ext]) => {
+        const filePath = path.join(thumbDownloadsDir, `${videoId}.${ext}`)
         SyncUtils.setVideoAssetPath(videoId, 'thumbnail', filePath)
         SyncUtils.updateUsedStorageSize(this.fileSize(filePath))
         return videoId

--- a/src/services/syncProcessing/ContentDownloadService.ts
+++ b/src/services/syncProcessing/ContentDownloadService.ts
@@ -109,7 +109,7 @@ export class ContentDownloadService {
     )
     try {
       await promisify(exec)(
-        `${this.proxyService?.proxychainExec?.concat(' ')}` +
+        `${this.proxyService?.proxychainExec?.concat(' ') || ''}` +
         `node ${DOWNLOAD_ASSET_SCRIPT_PATH} ` +
         `${assetUrl} ` +
         `${thumbnailPath} ` +

--- a/src/services/syncProcessing/ContentDownloadService.ts
+++ b/src/services/syncProcessing/ContentDownloadService.ts
@@ -75,8 +75,9 @@ export class ContentDownloadService {
       })
     const resolvedThumbs = fs
       .readdirSync(path.join(videoDownloadsDir, THUMBNAILS_SUBDIR))
-      .map((filePath) => {
-        const [videoId, ext] = filePath.split('.')
+      .map((fileName) => {
+        const [videoId, ext] = fileName.split('.')
+        const filePath = path.join(this.config.downloadsDir, fileName)
         if (ext.includes('.')) {
           // Remove partially downloaded thumbnails
           try {

--- a/src/services/syncProcessing/ContentDownloadService.ts
+++ b/src/services/syncProcessing/ContentDownloadService.ts
@@ -77,7 +77,7 @@ export class ContentDownloadService {
       .readdirSync(path.join(videoDownloadsDir, THUMBNAILS_SUBDIR))
       .map((fileName) => {
         const [videoId, ext] = fileName.split('.')
-        const filePath = path.join(this.config.downloadsDir, fileName)
+        const filePath = path.join(this.config.downloadsDir, THUMBNAILS_SUBDIR, fileName)
         if (ext.includes('.')) {
           // Remove partially downloaded thumbnails
           try {

--- a/src/services/syncProcessing/ContentDownloadService.ts
+++ b/src/services/syncProcessing/ContentDownloadService.ts
@@ -2,6 +2,8 @@ import { Job } from 'bullmq'
 import fs, { promises as fsp } from 'fs'
 import fsPromises from 'fs/promises'
 import pTimeout from 'p-timeout'
+import { exec } from 'child_process'
+import { promisify } from 'util'
 import path from 'path'
 import { Logger } from 'winston'
 import { IDynamodbService } from '../../repository'
@@ -10,16 +12,21 @@ import { DownloadJobData, DownloadJobOutput, DurationLimitExceededError, VideoUn
 import { LoggingService } from '../logging'
 import { IYoutubeApi } from '../youtube/api'
 import { SyncUtils } from './utils'
+import { Socks5ProxyService } from '../proxy/Socks5ProxyService'
+import { SCRIPT_PATH as DOWNLOAD_ASSET_SCRIPT_PATH } from '../../scripts/downloadAsset'
+
+export const THUMBNAILS_SUBDIR = 'thumbs'
 
 // Youtube videos download service
 export class ContentDownloadService {
   readonly logger: Logger
 
   public constructor(
-    private config: Required<ReadonlyConfig['sync']> & ReadonlyConfig['proxy'],
+    private config: Required<ReadonlyConfig['sync']>,
     logging: LoggingService,
     private dynamodbService: IDynamodbService,
-    private youtubeApi: IYoutubeApi
+    private youtubeApi: IYoutubeApi,
+    private proxyService?: Socks5ProxyService
   ) {
     this.logger = logging.createLogger('ContentDownloadService')
   }
@@ -31,22 +38,22 @@ export class ContentDownloadService {
     this.resolveDownloadedVideos()
   }
 
-  private async removeVideoFile(videoId: string) {
+  private async removeAllVideoFiles(videoId: string) {
     try {
       const dir = this.config.downloadsDir
-      const files = await fsPromises.readdir(dir)
-      for (const file of files) {
-        if (file.startsWith(videoId)) {
-          const filePath = path.join(dir, file)
+      const videoDirEntries = await fsPromises.readdir(dir, { withFileTypes: true })
+      const thumbDirEntries = await fsPromises.readdir(path.join(dir, THUMBNAILS_SUBDIR), { withFileTypes: true })
+      for (const entry of videoDirEntries.concat(thumbDirEntries)) {
+        if (entry.isFile() && entry.name.startsWith(videoId)) {
+          const filePath = path.join(dir, entry.name)
           const size = fs.statSync(filePath).size
-          SyncUtils.updateUsedStorageSize(-size)
-
           await fsPromises.unlink(filePath)
+          SyncUtils.updateUsedStorageSize(-size)
         }
       }
-      SyncUtils.downloadedVideoFilePaths.delete(videoId)
+      SyncUtils.downloadedVideoAssetPaths.delete(videoId)
     } catch (err) {
-      this.logger.error(`Failed to delete media file for video. File not found.`, { videoId: videoId, err })
+      this.logger.error(`Failed to remove all files associated with video.`, { videoId: videoId, err })
     }
   }
 
@@ -56,20 +63,62 @@ export class ContentDownloadService {
 
   private resolveDownloadedVideos() {
     const videoDownloadsDir = this.config.downloadsDir
-    const resolvedDownloads = fs
+    const resolvedVideos = fs
       .readdirSync(videoDownloadsDir)
       .map((filePath) => filePath.split('.'))
       .filter((filePath) => filePath.length === 2)
       .map(([videoId, ext]) => {
         const filePath = path.join(this.config.downloadsDir, `${videoId}.${ext}`)
-        SyncUtils.setVideoFilePath(videoId, filePath)
+        SyncUtils.setVideoAssetPath(videoId, 'video', filePath)
+        SyncUtils.updateUsedStorageSize(this.fileSize(filePath))
+        return videoId
+      })
+    const resolvedThumbs = fs
+      .readdirSync(path.join(videoDownloadsDir, THUMBNAILS_SUBDIR))
+      .map((filePath) => {
+        const [videoId, ext] = filePath.split('.')
+        if (ext.includes('.')) {
+          // Remove partially downloaded thumbnails
+          try {
+            fs.unlinkSync(filePath)
+          } catch (e: any) {
+            this.logger.warn(`Failed to remove ${filePath}: ${e.toString()}`)
+          }
+        }
+        SyncUtils.setVideoAssetPath(videoId, 'thumbnail', filePath)
         SyncUtils.updateUsedStorageSize(this.fileSize(filePath))
         return videoId
       })
     this.logger.verbose(`Resolved already downloaded video assets in local storage`, {
-      resolvedDownloads: resolvedDownloads.length,
+      resolvedVideos: resolvedVideos.length,
+      resolvedThumbs: resolvedThumbs.length,
       usedSpace: SyncUtils.usedSpace,
     })
+  }
+
+  async downloadThumbnail(video: DownloadJobData, proxy?: string): Promise<string> {
+    const assetUrl = video.thumbnails?.medium
+    if (!assetUrl) {
+      throw new Error(`Cannot download thumbnail: Missing thumbnail asset url`)
+    }
+    const [ext] = assetUrl.split('.').slice(-1)
+    const thumbnailPath = path.join(
+      this.config.downloadsDir,
+      THUMBNAILS_SUBDIR,
+      `${video.id}.${ext}`,
+    )
+    try {
+      await promisify(exec)(
+        `${this.proxyService?.proxychainExec?.concat(' ')}` +
+        `node ${DOWNLOAD_ASSET_SCRIPT_PATH} ` +
+        `${assetUrl} ` +
+        `${thumbnailPath} ` +
+        `${proxy}` 
+      )
+    } catch (e: any) {
+      throw new Error(`Thumbnail download failed: ${e.toString()}`)
+    }
+    return thumbnailPath
   }
 
   /// Process download tasks based on their priority.
@@ -84,8 +133,11 @@ export class ContentDownloadService {
       const channel = await this.dynamodbService.channels.getById(video.channelId)
       const isHistoricalVideo = new Date(video.publishedAt) < channel.createdAt
 
+      // Establish a proxy endpoint to use
+      const proxy = await this.proxyService?.getProxy(video.id)
+
       // check available video formats before attempting to download
-      const ytpMetadata = await this.youtubeApi.checkVideo(video.url)
+      const ytpMetadata = await this.youtubeApi.checkVideo(video.url, proxy)
       // check historical videos size cap
       const expectedFilesize = ytpMetadata.filesize_approx
       if (
@@ -95,24 +147,40 @@ export class ContentDownloadService {
       ) {
         throw new Error(`aborted: size cap for historical videos of channel ${channel.id} reached.`)
       }
-      
-      // download the video from youtube
-      const ytpOutput = await pTimeout(
-        this.youtubeApi.downloadVideo(video.url, this.config.downloadsDir),
-        this.config.limits.pendingDownloadTimeoutSec * 1000,
-        `Download timed-out`
-      )
 
-      const { ext: fileExt } = ytpOutput
-      const filePath = path.join(this.config.downloadsDir, `${video.id}.${fileExt}`)
-      const size = this.fileSize(filePath)
-      if (!SyncUtils.downloadedVideoFilePaths.has(video.id)) {
-        SyncUtils.setVideoFilePath(video.id, filePath)
-        SyncUtils.updateUsedStorageSize(size)
+      const alreadyDownloadedAssets = SyncUtils.downloadedVideoAssetPaths.get(video.id)
+      // download thumbnail if missing
+      if (!alreadyDownloadedAssets?.thumbnail) {
+        const thumbnailPath = await this.downloadThumbnail(video, proxy)
+        const thumbnailSize = this.fileSize(thumbnailPath)
+        SyncUtils.setVideoAssetPath(video.id, 'thumbnail', thumbnailPath)
+        SyncUtils.updateUsedStorageSize(thumbnailSize)
+      } else {
+        this.logger.info(`Thumbnail already downloaded, skipping...`, { jobId: video.id })
+      }
+      
+      // download the video from youtube if missing
+      if (!alreadyDownloadedAssets?.video) {
+        const ytpOutput = await pTimeout(
+          this.youtubeApi.downloadVideo(video.url, this.config.downloadsDir, proxy),
+          this.config.limits.pendingDownloadTimeoutSec * 1000,
+          `Download timed-out`
+        )
+        const { ext: fileExt } = ytpOutput
+        const videoPath = path.join(this.config.downloadsDir, `${video.id}.${fileExt}`)
+        const videoSize = this.fileSize(videoPath)
+        SyncUtils.setVideoAssetPath(video.id, 'video', videoPath)
+        SyncUtils.updateUsedStorageSize(videoSize)
+      } else {
+        this.logger.info(`Video already downloaded, skipping...`, { jobId: video.id })
       }
 
+      const videoAssets = SyncUtils.expectedVideoAssetPaths(video.id)
+      const assetsSize = Object.values(videoAssets).reduce((sizeSum, assetPath) => sizeSum += this.fileSize(assetPath), 0)
+
+      // TODO: Why would that ever happen?
       if (video.joystreamVideo) {
-        return { filePath }
+        return videoAssets
       }
 
       /**
@@ -120,17 +188,19 @@ export class ContentDownloadService {
        * violate per channel total videos count & size limits)
        */
       if (isHistoricalVideo) {
-        const sizeLimitReached = channel.historicalVideoSyncedSize + size > YtChannel.sizeCap(channel)
+        const sizeLimitReached = channel.historicalVideoSyncedSize + assetsSize > YtChannel.sizeCap(channel)
         if (sizeLimitReached) {
           throw new Error(`size cap for historical videos of channel ${channel.id} reached.`)
         }
       }
 
-      return { filePath }
+      return videoAssets
     } catch (err) {
+      const usedProxy = this.proxyService?.unbindProxy(video.id)
+      const logDetails = { videoId: video.id, proxy: usedProxy }
       if (err instanceof DurationLimitExceededError) {
         // Skip video creation
-        this.logger.error(`${err.message}. Skipping from syncing...`),
+        this.logger.error(`${err.message}. Skipping from syncing...`, { ...logDetails }),
         await this.dynamodbService.videos.updateState(video, 'VideoUnavailable::Skipped')
       } else {
         const errorMsg = (err as Error).message
@@ -153,20 +223,19 @@ export class ContentDownloadService {
         let matchedError = errors.find((e) => errorMsg.includes(e.message))
         if (matchedError) {
           await this.dynamodbService.videos.updateState(video, `VideoUnavailable::${matchedError.code}`)
-          this.logger.error(`${errorMsg}. Skipping from syncing...`, { videoId: video.id, reason: matchedError.code })
+          this.logger.error(`${errorMsg}. Skipping from syncing...`, { ...logDetails, reason: matchedError.code })
         }
-
-        console.log('errorMsg', errorMsg)
-
-        // If the error is 403 Forbidden means the IP address was blocked
-        if (errorMsg.includes('Sign in to confirm')) {
-          console.log('Download blocked by youtube')
+        else if (errorMsg.includes('Sign in to confirm you’re not a bot.')) {
+          this.logger.error('Download blocked by YouTube', { ...logDetails })
+          if (usedProxy) {
+            this.proxyService?.reportFaultyProxy(usedProxy)
+          }
         }
       }
 
       // TODO: If Download timed out, should we keep it on disk so it can be resumed later?
 
-      await this.removeVideoFile(video.id)
+      await this.removeAllVideoFiles(video.id)
       throw err
     }
   }

--- a/src/services/syncProcessing/ContentMetadataService.ts
+++ b/src/services/syncProcessing/ContentMetadataService.ts
@@ -59,7 +59,7 @@ export class ContentMetadataService {
 
     const { maxVideoSizeMB, maxVideoDuration } = this.config.limits
     if (
-      (maxVideoSizeMB && mediaMetadata.size > maxVideoSizeMB) || 
+      (maxVideoSizeMB && mediaMetadata.size > maxVideoSizeMB * 1_000_000) || 
       (maxVideoDuration && mediaMetadata.duration && mediaMetadata.duration > maxVideoDuration)
     ) {
       // Skip video creation
@@ -70,7 +70,7 @@ export class ContentMetadataService {
 
       // Throw error to stop processing
       throw new Error(`Video size or duration exceeds the limit (`+
-        `size: ${mediaMetadata.size} / ${maxVideoSizeMB}, `+
+        `size: ${mediaMetadata.size} / ${maxVideoSizeMB ? maxVideoSizeMB * 1_000_000 : undefined}, `+
         `duration: ${mediaMetadata.duration} / ${maxVideoDuration}` +
       `). Video skipped.`)
     }

--- a/src/services/syncProcessing/ContentMetadataService.ts
+++ b/src/services/syncProcessing/ContentMetadataService.ts
@@ -6,9 +6,10 @@ import { IDynamodbService } from '../../repository'
 import { DownloadJobOutput, MetadataJobData, MetadataJobOutput } from '../../types/youtube'
 import { FileHash, computeFileHashAndSize } from '../../utils/hasher'
 import { LoggingService } from '../logging'
-import { getThumbnailAsset, getVideoFileMetadata } from '../runtime/client'
+import { getVideoFileMetadata } from '../runtime/client'
 import { VideoFileMetadata } from '../runtime/types'
 import { SyncUtils } from './utils'
+import { ReadonlyConfig } from '../../types'
 
 export type VideoMetadataAndHash = {
   thumbnailHash: FileHash
@@ -22,7 +23,11 @@ export type VideoMetadataAndHash = {
 export class ContentMetadataService {
   readonly logger: Logger
 
-  public constructor(logging: LoggingService, private dynamodbService: IDynamodbService) {
+  public constructor(
+    private config: Required<ReadonlyConfig['sync']>,
+    logging: LoggingService,
+    private dynamodbService: IDynamodbService
+  ) {
     this.logger = logging.createLogger('ContentHashingService')
   }
 
@@ -39,30 +44,35 @@ export class ContentMetadataService {
       throw new Error(`Failed to get video file path from 'completed' child job: ${video.id}. File not found.`)
     }
 
-    const videoHashStream = fs.createReadStream(downloadJobOutput.filePath)
-    const thumbnailPhotoStream = await getThumbnailAsset(video.thumbnails)
+    const videoHashStream = fs.createReadStream(downloadJobOutput.video)
+    const thumbnailPhotoStream = fs.createReadStream(downloadJobOutput.thumbnail)
 
     const [thumbnailHash, mediaHash, mediaMetadata] = await pTimeout(
       Promise.all([
         computeFileHashAndSize(thumbnailPhotoStream),
         computeFileHashAndSize(videoHashStream),
-        getVideoFileMetadata(downloadJobOutput.filePath),
+        getVideoFileMetadata(downloadJobOutput.video),
       ]),
       30 * 60 * 1000, // 30 mins
       'Video metadata & hash calculation operation timed=out'
     )
 
-    // For any channel max size of a single synced video is 15 GB
-    // For any channel max duration of synced video is 3 hrs
-    if (mediaMetadata.size > 15_000_000_000 || (mediaMetadata.duration && mediaMetadata.duration > 10800)) {
+    const { maxVideoSizeMB, maxVideoDuration } = this.config.limits
+    if (
+      (maxVideoSizeMB && mediaMetadata.size > maxVideoSizeMB) || 
+      (maxVideoDuration && mediaMetadata.duration && mediaMetadata.duration > maxVideoDuration)
+    ) {
       // Skip video creation
       await this.dynamodbService.videos.updateState(video, 'VideoUnavailable::Skipped')
 
       // Remove video file
-      await SyncUtils.removeVideoFile(video.id)
+      await SyncUtils.removeVideoAssets(video.id)
 
       // Throw error to stop processing
-      throw new Error('Video size or duration exceeds the limit. Video skipped.')
+      throw new Error(`Video size or duration exceeds the limit (`+
+        `size: ${mediaMetadata.size} / ${maxVideoSizeMB}, `+
+        `duration: ${mediaMetadata.duration} / ${maxVideoDuration}` +
+      `). Video skipped.`)
     }
     return { thumbnailHash, mediaHash, mediaMetadata }
   }

--- a/src/services/syncProcessing/PriorityQueue.ts
+++ b/src/services/syncProcessing/PriorityQueue.ts
@@ -29,6 +29,8 @@ export interface ProcessorInstance<P, T, R> {
   process: P extends 'concurrent' ? ConcurrentProcessor<T, R> : BatchProcessor<T>
 }
 
+type JobFailureHandler = (jobId: string | undefined, err: Error) => void
+
 type PriorityQueueOptions<
   N extends QueueName = QueueName,
   P extends ProcessorType = ProcessorType,
@@ -40,6 +42,7 @@ type PriorityQueueOptions<
   processorType: P
   concurrencyOrBatchSize: number
   processorInstance: I
+  onFailure?: JobFailureHandler
 }
 
 class PriorityJobQueue<
@@ -60,11 +63,13 @@ class PriorityJobQueue<
   readonly queue: Queue<T>
   private worker: Worker
   private connection: IORedis
+  private customFailureHandler?: JobFailureHandler
 
   constructor(redis: ReadonlyConfig['endpoints']['redis'], options: PriorityQueueOptions<N, P, T, R, I>) {
     this.logger = options.processorInstance.logger
     this.concurrencyOrBatchSize = options.concurrencyOrBatchSize
     this.connection = new IORedis(redis.port, redis.host, { maxRetriesPerRequest: null })
+    this.customFailureHandler = options.onFailure
 
     this.queue = new Queue(options.name, { connection: this.connection })
     this.RECALCULATE_PRIORITY_LOCK_KEY = this.queue.name
@@ -79,6 +84,29 @@ class PriorityJobQueue<
   }
 
   processingTasks = new Set<string>()
+
+  private setupEventHandlers(worker: Worker<T, R, string>) {
+    worker.on('active', (job) => {
+      this.logger.debug(`Started job in queue '${this.queue.name}'`, { jobId: job.data.id })
+    })
+
+    worker.on('completed', (job) => {
+      this.logger.debug(`Completed job in queue '${this.queue.name}'`, { jobId: job.data.id })
+    })
+
+    worker.on('failed', (job, err) => {
+      if (this.customFailureHandler) {
+        this.customFailureHandler(job?.data.id, err)
+      } else {
+        this.logger.error(`Failed job in queue '${this.queue.name}'`, { jobId: job?.data.id, err })
+      }
+    })
+
+    worker.on('error', (err) => {
+      // log the error
+      this.logger.error(err)
+    })
+  }
 
   private setupConcurrentProcessing(processor: ConcurrentProcessor<T, R>) {
     const wrappedProcessor = async (job: Job<T, R>) => {
@@ -102,22 +130,7 @@ class PriorityJobQueue<
       skipStalledCheck: true,
     })
 
-    this.worker.on('active', (job) => {
-      this.logger.debug(`Started job in queue '${this.queue.name}'`, { jobId: job.data.id })
-    })
-
-    this.worker.on('completed', (job) => {
-      this.logger.debug(`Completed job in queue '${this.queue.name}'`, { jobId: job.data.id })
-    })
-
-    this.worker.on('failed', (job, err) => {
-      this.logger.error(`Failed job in queue '${this.queue.name}'`, { jobId: job?.data.id, err: err?.message })
-    })
-
-    this.worker.on('error', (err) => {
-      // log the error
-      this.logger.error(err)
-    })
+    this.setupEventHandlers(this.worker)
   }
 
   /**
@@ -131,6 +144,7 @@ class PriorityJobQueue<
       connection: this.connection,
       lockDuration: jobsLockDuration,
     })
+    this.setupEventHandlers(this.worker)
 
     // get `N` next jobs that need to be processed
     const getNJobs = async (n: number): Promise<Job[]> => {

--- a/src/services/syncProcessing/PriorityQueue.ts
+++ b/src/services/syncProcessing/PriorityQueue.ts
@@ -29,7 +29,9 @@ export interface ProcessorInstance<P, T, R> {
   process: P extends 'concurrent' ? ConcurrentProcessor<T, R> : BatchProcessor<T>
 }
 
-type JobFailureHandler = (jobId: string | undefined, err: Error) => void
+type JobFailureHandler =
+  ((jobId: string | undefined, err: Error) => void) |
+  ((jobId: string | undefined, err: Error, logger: Logger) => void)
 
 type PriorityQueueOptions<
   N extends QueueName = QueueName,
@@ -96,7 +98,7 @@ class PriorityJobQueue<
 
     worker.on('failed', (job, err) => {
       if (this.customFailureHandler) {
-        this.customFailureHandler(job?.data.id, err)
+        this.customFailureHandler(job?.data.id, err, this.logger)
       } else {
         this.logger.error(`Failed job in queue '${this.queue.name}'`, { jobId: job?.data.id, err })
       }

--- a/src/services/syncProcessing/index.ts
+++ b/src/services/syncProcessing/index.ts
@@ -107,9 +107,9 @@ export class ContentProcessingService extends ContentProcessingClient implements
     // create job queues
 
     const { maxConcurrentDownloads, maxConcurrentUploads, createVideoTxBatchSize } = this.config.limits
-    const onFailedJob = (queueName: string) => (jobId: string | undefined, err: Error) => {
+    const onFailedJob = (queueName: string) => (jobId: string | undefined, err: Error, logger: Logger) => {
       const usedProxy = jobId ? this.proxyService?.unbindProxy(jobId) : undefined
-      this.logger.error(`Failed job in queue '${queueName}'`, { jobId, proxy: usedProxy, err })
+      logger.error(`Failed job in queue '${queueName}'`, { jobId, proxy: usedProxy, err })
     }
     this.flowManager.createJobQueue({
       name: 'DownloadQueue',

--- a/src/services/syncProcessing/utils.ts
+++ b/src/services/syncProcessing/utils.ts
@@ -40,7 +40,8 @@ export class SyncUtils {
       throw new Error(`Failed to get assets paths for video: ${videoId}.`)
     }
     for (const assetType of videoAssetTypes) {
-      if (!assetPaths[assetType] || !fs.existsSync(assetPaths[assetType])) {
+      const assetPath = assetPaths[assetType]
+      if (!assetPath || !fs.existsSync(assetPath)) {
         throw new Error(`Failed to get ${assetType} file path for video: ${videoId}. File not found.`)
       }
     }

--- a/src/services/youtube/api.ts
+++ b/src/services/youtube/api.ts
@@ -505,7 +505,7 @@ export class YoutubeClient implements IYoutubeApi {
     this.logger.debug(`Checking video`, { proxy, videoUrl })
 
     const { maxVideoSizeMB } = this.config.sync.limits || {}
-    const executable = `${this.proxyService?.proxychainExec?.concat(' ')}${YT_DLP_PATH}`
+    const executable = `${this.proxyService?.proxychainExec?.concat(' ') || ''}${YT_DLP_PATH}`
     const response = await create(executable)(videoUrl, {
       dumpJson: true,
       simulate: true,
@@ -529,7 +529,7 @@ export class YoutubeClient implements IYoutubeApi {
     this.logger.debug(`Downloading video`, { proxy, videoUrl, preDownloadSleepTime })
 
     const { maxVideoSizeMB } = this.config.sync.limits || {}
-    const executable = `${this.proxyService?.proxychainExec?.concat(' ')}${YT_DLP_PATH}`
+    const executable = `${this.proxyService?.proxychainExec?.concat(' ') || ''}${YT_DLP_PATH}`
     const response = await create(executable)(videoUrl, {
       noWarnings: true,
       abortOnError: true,

--- a/src/services/youtube/api.ts
+++ b/src/services/youtube/api.ts
@@ -479,16 +479,6 @@ export class YoutubeClient implements IYoutubeApi {
     return videos
   }
 
-  async preDownloadSleep(): Promise<number | undefined> {
-    const {preDownloadSleep} = this.config.sync.limits || {}
-    if (preDownloadSleep) {
-      const { min, max } = preDownloadSleep
-      const sleepTime = _.random(min, max)
-      await sleep(sleepTime)
-      return sleepTime
-    }
-  }
-
   private getAcceptedFormats(): string[] {
     const { maxVideoSizeMB } = this.config.sync.limits || {}
     const sizeFormat = maxVideoSizeMB ?
@@ -524,9 +514,7 @@ export class YoutubeClient implements IYoutubeApi {
   }
 
   async downloadVideo(videoUrl: string, outPath: string, proxy?: string): ReturnType<typeof ytdl> {
-    const preDownloadSleepTime = await this.preDownloadSleep()
-    
-    this.logger.debug(`Downloading video`, { proxy, videoUrl, preDownloadSleepTime })
+    this.logger.debug(`Downloading video`, { proxy, videoUrl })
 
     const { maxVideoSizeMB } = this.config.sync.limits || {}
     const executable = `${this.proxyService?.proxychainExec?.concat(' ') || ''}${YT_DLP_PATH}`

--- a/src/services/youtube/api.ts
+++ b/src/services/youtube/api.ts
@@ -21,6 +21,7 @@ import Schema$Channel = youtube_v3.Schema$Channel
 import Schema$Video = youtube_v3.Schema$Video
 import { LoggingService } from '../logging'
 import { Logger } from 'winston'
+import { Socks5ProxyService } from '../proxy/Socks5ProxyService'
 
 const YT_DLP_PATH = path.join(
   path.dirname(require.resolve('youtube-dl-exec/package.json')),
@@ -195,8 +196,8 @@ export interface IYoutubeApi {
   ): Promise<{ channel: YtChannel; errors: YoutubeApiError[] }>
   getVideos(channel: YtChannel, top: number): Promise<YtVideo[]>
   getYoutubeVideosByIds(ids: string[]): Promise<YouTubeVideoData[]>
-  downloadVideo(videoUrl: string, outPath: string): ReturnType<typeof ytdl>
-  checkVideo(videoUrl: string): ReturnType<typeof ytdl> 
+  downloadVideo(videoUrl: string, outPath: string, proxy?: string): ReturnType<typeof ytdl>
+  checkVideo(videoUrl: string, proxy?: string): ReturnType<typeof ytdl> 
   getCreatorOnboardingRequirements(): ReadonlyConfig['creatorOnboardingRequirements']
 }
 
@@ -211,7 +212,7 @@ export class YoutubeClient implements IYoutubeApi {
   private logger: Logger
   readonly ytdlpClient: YtDlpClient
 
-  constructor(config: ReadonlyConfig, logging: LoggingService) {
+  constructor(config: ReadonlyConfig, logging: LoggingService, private proxyService?: Socks5ProxyService) {
     this.config = config
     this.logger = logging.createLogger('YoutubeClient')
     this.ytdlpClient = new YtDlpClient()
@@ -478,18 +479,6 @@ export class YoutubeClient implements IYoutubeApi {
     return videos
   }
 
-  getNextProxy() {
-    const proxies = this.config.proxy?.urls
-    if (!proxies) {
-      return undefined
-    }
-    ++this.proxyIdx
-    if (this.proxyIdx >= proxies.length) {
-      this.proxyIdx = 0
-    }
-    return proxies[this.proxyIdx]
-  }
-
   async preDownloadSleep(): Promise<number | undefined> {
     const {preDownloadSleep} = this.config.sync.limits || {}
     if (preDownloadSleep) {
@@ -512,13 +501,11 @@ export class YoutubeClient implements IYoutubeApi {
     return formats
   }
 
-  async checkVideo(videoUrl: string): ReturnType<typeof ytdl> {
-    const proxy = this.getNextProxy()
-    
+  async checkVideo(videoUrl: string, proxy?: string): ReturnType<typeof ytdl> {
     this.logger.debug(`Checking video`, { proxy, videoUrl })
 
     const { maxVideoSizeMB } = this.config.sync.limits || {}
-    const executable = proxy ? `proxychains ${YT_DLP_PATH}` : YT_DLP_PATH
+    const executable = `${this.proxyService?.proxychainExec?.concat(' ')}${YT_DLP_PATH}`
     const response = await create(executable)(videoUrl, {
       dumpJson: true,
       simulate: true,
@@ -536,14 +523,13 @@ export class YoutubeClient implements IYoutubeApi {
     return response
   }
 
-  async downloadVideo(videoUrl: string, outPath: string): ReturnType<typeof ytdl> {
-    const proxy = this.getNextProxy()
+  async downloadVideo(videoUrl: string, outPath: string, proxy?: string): ReturnType<typeof ytdl> {
     const preDownloadSleepTime = await this.preDownloadSleep()
     
     this.logger.debug(`Downloading video`, { proxy, videoUrl, preDownloadSleepTime })
 
     const { maxVideoSizeMB } = this.config.sync.limits || {}
-    const executable = proxy ? `proxychains ${YT_DLP_PATH}` : YT_DLP_PATH
+    const executable = `${this.proxyService?.proxychainExec?.concat(' ')}${YT_DLP_PATH}`
     const response = await create(executable)(videoUrl, {
       noWarnings: true,
       abortOnError: true,
@@ -913,7 +899,7 @@ class QuotaMonitoringClient implements IQuotaMonitoringClient, IYoutubeApi {
 }
 
 export const YoutubeApi = {
-  create(config: ReadonlyConfig, statsRepo: StatsRepository, logging: LoggingService): IYoutubeApi {
-    return new QuotaMonitoringClient(new YoutubeClient(config, logging), config, statsRepo)
+  create(config: ReadonlyConfig, statsRepo: StatsRepository, logging: LoggingService, proxyService?: Socks5ProxyService): IYoutubeApi {
+    return new QuotaMonitoringClient(new YoutubeClient(config, logging, proxyService), config, statsRepo)
   },
 }

--- a/src/types/generated/ConfigJson.d.ts
+++ b/src/types/generated/ConfigJson.d.ts
@@ -255,9 +255,9 @@ export interface Socks5ProxyChainingConfiguration {
    */
   url: string
   /**
-   * Absolute path to a location where proxychains.conf file will be stored
+   * Absolute path to a location where proxychains4.conf file will be stored
    */
-  configPath: string
+  configDir: string
 }
 /**
  * Public api configuration

--- a/src/types/generated/ConfigJson.d.ts
+++ b/src/types/generated/ConfigJson.d.ts
@@ -234,11 +234,23 @@ export interface AWSCredentials {
  */
 export interface Socks5ProxyClientConfigurationUsedByYtDlpToBypassIPBlockageByYoutube {
   /**
+   * Url of the socks5 proxy through which all requests should be chained (if required to access other proxies).
+   */
+  chainThrough?: string
+  /**
    * List of available socks5 proxy URLs
    *
    * @minItems 1
    */
-  urls?: string[]
+  urls: string[]
+  /**
+   * How long should the application wait in case no proxies are available (in seconds)
+   */
+  waitInterval: number
+  /**
+   * How long should the proxy remain excluded in case it's blocked (in seconds)
+   */
+  exclusionDuration: number
 }
 /**
  * Public api configuration

--- a/src/types/generated/ConfigJson.d.ts
+++ b/src/types/generated/ConfigJson.d.ts
@@ -233,10 +233,7 @@ export interface AWSCredentials {
  * Socks5 proxy client configuration used by yt-dlp to bypass IP blockage by Youtube
  */
 export interface Socks5ProxyClientConfigurationUsedByYtDlpToBypassIPBlockageByYoutube {
-  /**
-   * Url of the socks5 proxy through which all requests should be chained (if required to access other proxies).
-   */
-  chainThrough?: string
+  chain?: Socks5ProxyChainingConfiguration
   /**
    * List of available socks5 proxy URLs
    *
@@ -251,6 +248,16 @@ export interface Socks5ProxyClientConfigurationUsedByYtDlpToBypassIPBlockageByYo
    * How long should the proxy remain excluded in case it's blocked (in seconds)
    */
   exclusionDuration: number
+}
+export interface Socks5ProxyChainingConfiguration {
+  /**
+   * Url of the socks5 proxy that all other proxy requests will be chained through.
+   */
+  url: string
+  /**
+   * Absolute path to a location where proxychains.conf file will be stored
+   */
+  configPath: string
 }
 /**
  * Public api configuration

--- a/src/types/youtube.ts
+++ b/src/types/youtube.ts
@@ -1,4 +1,5 @@
 import { VideoMetadataAndHash } from '../services/syncProcessing/ContentMetadataService'
+import { VideoAssetPaths } from '../services/syncProcessing/utils'
 
 type DeploymentEnv = 'dev' | 'local' | 'testing' | 'prod'
 const deploymentEnv = process.env.DEPLOYMENT_ENV as DeploymentEnv | undefined
@@ -367,9 +368,7 @@ export type DownloadJobData = YtVideo & {
   priority: number
 }
 
-export type DownloadJobOutput = {
-  filePath: string
-}
+export type DownloadJobOutput = Required<VideoAssetPaths>
 
 export type CreateVideoJobData = YtVideo & {
   priority: number


### PR DESCRIPTION
Improves proxy setup by introducing:
- faulty proxy exclusion (in case a proxy endpoint is blocked, it's temporarily excluded from use)
- proxy binding per video (all requests related to the same video use the same proxy)
- waiting period if no proxies are available (the app will wait if all of the proxy endpoints are either already in use or are excluded/disabled)
- configurable "intermediary" proxychains endpoint (if required in order to access proxies listed in `config.proxy.urls`)
- proxy for thumbnail downloads (addresses: https://github.com/Joystream/youtube-synch/issues/340)
- improved logging to easier identify faulty proxies