### PR TITLE
Update mainnet RPC endpoint

### DIFF
--- a/ypp-operations/docs/cli/payRewardForChannel.md
+++ b/ypp-operations/docs/cli/payRewardForChannel.md
@@ -21,6 +21,6 @@ OPTIONS
   --payerMemberId=payerMemberId          (required) Joystream member Id of Reward payer account
   --queryNodeEndpoint=queryNodeEndpoint  [default: https://query.joystream.org/graphql] Query node endpoint to use
 
-  --rpcEndpoint=rpcEndpoint              [default: wss://rpc.joystream.org:9944] RPC endpoint of the Joystream node to
+  --rpcEndpoint=rpcEndpoint              [default: wss://rpc.joystream.org] RPC endpoint of the Joystream node to
                                          connect to
 ```

--- a/ypp-operations/docs/cli/payRewards.md
+++ b/ypp-operations/docs/cli/payRewards.md
@@ -26,6 +26,6 @@ OPTIONS
 
   --queryNodeEndpoint=queryNodeEndpoint  [default: https://query.joystream.org/graphql] Query node endpoint to use
 
-  --rpcEndpoint=rpcEndpoint              [default: wss://rpc.joystream.org:9944] RPC endpoint of the Joystream node to
+  --rpcEndpoint=rpcEndpoint              [default: wss://rpc.joystream.org] RPC endpoint of the Joystream node to
                                          connect to
 ```

--- a/ypp-operations/src/cli/base/default.ts
+++ b/ypp-operations/src/cli/base/default.ts
@@ -24,7 +24,7 @@ export default abstract class DefaultCommandBase extends Command {
     }),
     rpcEndpoint: flags.string({
       required: false,
-      default: 'wss://rpc.joystream.org:9944',
+      default: 'wss://rpc.joystream.org',
       description: 'RPC endpoint of the Joystream node to connect to',
     }),
     queryNodeEndpoint: flags.string({


### PR DESCRIPTION
Replace `wss://rpc.joystream.org:9944` with `wss://rpc.joystream.org` as the former is no longer available.